### PR TITLE
Fixed hpa in v2beta2

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 1.0.3
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.0.0
+version: 2.0.1

--- a/charts/dotnet-core/templates/hpa.yaml
+++ b/charts/dotnet-core/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.global.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.global.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.global.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.global.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.global.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Recent bump in HPA API caused error in helm chart.
Adjusted HPA to work in v2beta2.

## Chart

Select the chart that you are modifying:
- [ ] core
- [X] dotnet-template
- [ ] azure-functions

## Checklist
- [X] Description provided
- [ ] Linked issue
- [X] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`