### PR TITLE
Pact broker chart

### DIFF
--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: pact-broker
 description: EcoVadis public Helm chart for Pact Broker
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.102.2.0
 sources:
   - https://github.com/pact-foundation/pact_broker
+  - https://github.com/ChrisJBurns/pact-broker-chart

--- a/charts/pact-broker/templates/_helpers.tpl
+++ b/charts/pact-broker/templates/_helpers.tpl
@@ -24,6 +24,26 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.name" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
 This allows us to not have image: .Values.xxxx.ssss/.Values.xxx.xxx:.Values.ssss
 in every single template.
 */}}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -3,23 +3,16 @@ kind: Deployment
 metadata:
   name: {{ include "chart.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.broker.replicaCount }}
   selector: 
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/name: {{ include "chart.name" . }}
+      {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "chart.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- with .Values.broker.labels }}
-        {{ toYaml . | trim | indent 8 }}
-        {{- end }}
+        {{- include "chart.labels" . | nindent 8 }}
       annotations:
         checksum/envconfig: {{ include (print $.Template.BasePath "/env-configmap.yaml") . | sha256sum }}
         checksum/secretconfig: {{ include (print $.Template.BasePath "/env-secret.yaml") . | sha256sum }}
@@ -43,9 +36,9 @@ spec:
             - name: http
               containerPort: {{ .Values.envVars.PACT_BROKER_PORT }}
               protocol: TCP
-            - name: https
-              containerPort: {{ .Values.broker.containerPorts.https }}
-              protocol: TCP
+            # - name: https
+            #   containerPort: {{ .Values.broker.containerPorts.https }}
+            #   protocol: TCP
           envFrom:
             - configMapRef:
                 name: "{{ include "chart.fullname" . }}"

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
       {{- if .Values.broker.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.broker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/charts/pact-broker/templates/deployment.yaml
+++ b/charts/pact-broker/templates/deployment.yaml
@@ -36,9 +36,6 @@ spec:
             - name: http
               containerPort: {{ .Values.envVars.PACT_BROKER_PORT }}
               protocol: TCP
-            # - name: https
-            #   containerPort: {{ .Values.broker.containerPorts.https }}
-            #   protocol: TCP
           envFrom:
             - configMapRef:
                 name: "{{ include "chart.fullname" . }}"

--- a/charts/pact-broker/templates/env-configmap.yaml
+++ b/charts/pact-broker/templates/env-configmap.yaml
@@ -3,11 +3,7 @@ kind: ConfigMap
 metadata:
   name: "{{ include "chart.fullname" . }}"
   labels:
-    name: {{ include "chart.fullname" . }}
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "chart.labels" . | nindent 4 }}
 data:
   {{ range $key, $value := .Values.envVars }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/pact-broker/templates/env-secret.yaml
+++ b/charts/pact-broker/templates/env-secret.yaml
@@ -3,11 +3,7 @@ kind: Secret
 metadata:
   name: "{{ include "chart.fullname" . }}-secure"
   labels:
-    name: {{ include "chart.fullname" . }}
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "chart.labels" . | nindent 4 }}
 data:
   {{ range $key, $value := .Values.secEnvVars }}
   {{ $key }}: {{ $value | b64enc }}

--- a/charts/pact-broker/templates/ingressroute.yaml
+++ b/charts/pact-broker/templates/ingressroute.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "chart.labels" . | nindent 4 }}
 spec:
   entryPoints:
-    - websecure
+    - web
   routes:
     - kind: Rule  
       match: Host(`{{ .Values.ingressRoute.host }}`)

--- a/charts/pact-broker/templates/ingressroute.yaml
+++ b/charts/pact-broker/templates/ingressroute.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingressRoute.enabled -}}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "chart.fullname" . }}-http
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule  
+      match: Host(`{{ .Values.ingressRoute.host }}`)
+      services:
+        - kind: Service
+          name: {{ include "chart.fullname" . }}
+          namespace: {{ .Release.Namespace }}
+          port: {{ .Values.ingressRoute.port }}
+{{- if kindIs "invalid" .Values.ingressRoute.isTlsEnabled }}
+  tls: {}
+{{ else if .Values.ingressRoute.isTlsEnabled }}
+  tls: {}
+{{- end }}
+{{- end -}}

--- a/charts/pact-broker/templates/service.yaml
+++ b/charts/pact-broker/templates/service.yaml
@@ -3,11 +3,7 @@ kind: Service
 metadata:
   name: {{ include "chart.fullname" . }}
   labels:
-    name: {{ include "chart.fullname" . }}
-    app.kubernetes.io/name: {{ include "chart.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "chart.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -23,12 +19,11 @@ spec:
     - name: https
       port: {{ .Values.service.ports.https }}
       protocol: TCP
-      targetPort: https
+      targetPort: http
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.https))) }}
       nodePort: {{ .Values.service.nodePorts.https }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
   selector:
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/name: {{ include "chart.name" . }}
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/charts/pact-broker/templates/serviceaccount.yaml
+++ b/charts/pact-broker/templates/serviceaccount.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/component: pact-broker
-      {{- with .Values.serviceAccount.labels }}
-      {{ toYaml . | trim | indent 8 }}
-      {{- end }}
+    {{- include "chart.labels" . | nindent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
     {{- with .Values.serviceAccount.annotations }}

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -15,6 +15,7 @@ envVars:
   PACT_BROKER_DISABLE_SSL_VERIFICATION: false # -- If set to true, SSL verification will be disabled for the HTTP requests made by the webhooks
   PACT_BROKER_ALLOW_PUBLIC_READ: false # -- Set to true if you want public read access, but still require credentials for writing.
   PACT_BROKER_ENABLE_PUBLIC_BADGE_ACCESS: false       # -- Set this to true to allow status badges to be embedded in README files without requiring a hardcoded password.
+  PACT_BROKER_HIDE_PACTFLOW_MESSAGES: true # -- Set to true to hide the messages in the logs about Pactflow
 
 secEnvVars:
   PACT_BROKER_DATABASE_USERNAME: "#{pbDbUser}#" # -- Non-root username for the Pact Broker
@@ -26,7 +27,6 @@ secEnvVars:
 
 # -- Broker configuration
 broker:
-  labels: {} # -- Additional labels that can be added to the Broker deployment
   annotations: {} # -- Additional annotations that can be added to the Broker deployment
   replicaCount: 1 # -- Number of Pact Broker replicas to deploy
   containerPorts:
@@ -82,10 +82,16 @@ service:
     http: "" # -- http nodePort
     https: "" # -- https nodePort
 
-# -- Service Account Configuration
+# -- Service Account configuration
 serviceAccount:
   create: true # -- Enable the creation of a ServiceAccount for Pact Broker pods
   name: pact-broker-sa # -- Name of the created ServiceAccount. If not set and `serviceAccount.create` is true, a name is generated
-  labels: {} # -- Additional custom labels to the service ServiceAccount.
   annotations: {} # -- Additional custom annotations for the ServiceAccount.
   automountServiceAccountToken: true # -- Auto-mount the service account token in the pod
+
+# -- Traefik ingress route configuration
+ingressRoute:
+  enabled: true
+  isTlsEnabled: false
+  host: "pact-broker.ecovadis-itlab.com"
+  port: 80

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -4,6 +4,8 @@ image:
   repository: pactfoundation/pact-broker # -- Pact Broker image repository
   tag: 2.102.2.0 # -- Pact Broker image tag (immutable tags are recommended) https://hub.docker.com/r/pactfoundation/pact-broker/tags
   pullPolicy: IfNotPresent # -- Specify a imagePullPolicy
+  pullSecrets: # -- Array of imagePullSecrets to allow pulling the Pact Broker image from private registries: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    - dockerhub-pull-secret # -- It is recommended to create this secret and store docker.io credentials inside. Even when we are pulling image from a public repo there are may be transient errors when pulling without imagePullSecrets.
 
 envVars:
   PACT_BROKER_DATABASE_ADAPTER: "postgres" # -- Database engine to use.


### PR DESCRIPTION
## Description

Traefik IngressRoute CRD is added, so now there is basic ingress support without TLS configured.
Some cosmetic changes to labels.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-template
- [x] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`