### PR TITLE
charts-core version bump, Readme change to trigger chart releaser

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 1.0.3
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.0.2
+version: 2.0.3

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -52,7 +52,7 @@ There is a special entry at `image.pullSecrets` in v`alues.yaml` file that passe
 
 It is recommended to [create](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) and use this secret and not to use anonymous image pulling because there is an issue with dockerhub repos when you may face image pull errors from public repos.
 
-Disable imagePullSecrets:
+To disable imagePullSecrets:
 ```
 image:
   pullSecrets: []


### PR DESCRIPTION
## Description

Briefly describe the problem and solution.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [x] pact-broker
- [ ] azure-functions

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`