### PR TITLE
Elastic outside cluster

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.3
+version: 1.0.4

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -88,6 +88,12 @@ spec:
       ports:
         - port: 9200
         - port: 8200
+    - to: #any elastic or apm outside of the cluster
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 9200
+        - port: 8200
 {{- if .Values.global.redisNetworkPolicyEnabled }}
     - to: #redis
         - ipBlock:

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -5,6 +5,6 @@ name: charts-dotnet-core
 type: application
 dependencies:
 - name: charts-core
-  version: 1.0.3
+  version: 1.0.4
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.0.3
+version: 2.0.4


### PR DESCRIPTION
## Description

I want to allow network flow to elastic outside of the cluster, may it be for Cluster A/B or ElasticCloud scenarios.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`