### PR TITLE
two step version upgrade

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -5,6 +5,6 @@ name: charts-dotnet-core
 type: application
 dependencies:
 - name: charts-core
-  version: 1.0.4
+  version: 1.0.3
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.0.4
+version: 2.0.3


### PR DESCRIPTION
## Description

It seems that core chart needs to be published first before new version may be referenced in dotnet chart

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`