### PR TITLE
Create a switch to avoid default values for httpGet live/readiness probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.lock
 **/*.lock
 .pytest_cache
+charts

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 1.2.0
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.1.2
+version: 2.1.3

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -61,10 +61,32 @@ spec:
           {{- end }}
           ports:
             {{- toYaml .Values.global.image.ports | nindent 12 }}
+          
           livenessProbe:
+          {{- if .Values.global.image.livenessProbe }}
             {{- toYaml .Values.global.image.livenessProbe | nindent 12 }}
+          {{- else }}
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 60
+            timeoutSeconds: 15
+            successThreshold: 1
+          {{- end }}
+          
           readinessProbe:
+          {{- if .Values.global.image.readinessProbe }}
             {{- toYaml .Values.global.image.readinessProbe | nindent 12 }}
+          {{- else }}
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            successThreshold: 1
+          {{- end }}
+            
           {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled }}
           envFrom:
           {{- if .Values.global.envVarsEnabled }}

--- a/charts/dotnet-core/templates/tests/deployment_test.py
+++ b/charts/dotnet-core/templates/tests/deployment_test.py
@@ -167,7 +167,7 @@ class DeploymentTemplateFileTest(unittest.TestCase):
             show_only=["templates/deployment.yaml"]
         )
         self.assertEqual(
-            "RELEASE-NAME-charts-dotnet-core",
+            "release-name-charts-dotnet-core",
             jmespath.search(
                 "spec.template.spec.containers[0].envFrom[0].configMapRef.name", docs[0])
         )
@@ -193,7 +193,7 @@ class DeploymentTemplateFileTest(unittest.TestCase):
             show_only=["templates/deployment.yaml"]
         )
         self.assertEqual(
-            "RELEASE-NAME-charts-dotnet-core-secure",
+            "release-name-charts-dotnet-core-secure",
             jmespath.search(
                 "spec.template.spec.containers[0].envFrom[0].secretRef.name", docs[0])
         )
@@ -262,10 +262,11 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                     "path": "/test/path",
                     "port": "443"
                 },
-                "periodSeconds": 10,
-                'initialDelaySeconds': 20,
-                "successThreshold": 1,
-                "timeoutSeconds": 3
+                # must be set separately with new probe switch
+                # "periodSeconds": 10,
+                # 'initialDelaySeconds': 20,
+                # "successThreshold": 1,
+                # "timeoutSeconds": 3
             },
             jmespath.search(
                 "spec.template.spec.containers[0].readinessProbe", docs[0])
@@ -295,9 +296,10 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                     "path": "/test/path",
                     "port": "443"
                 },
-                "periodSeconds": 60,
-                "successThreshold": 1,
-                "timeoutSeconds": 15
+                # must be set separately with new probe switch
+                # "periodSeconds": 60,
+                # "successThreshold": 1,
+                # "timeoutSeconds": 15
             },
             jmespath.search(
                 "spec.template.spec.containers[0].livenessProbe", docs[0])
@@ -458,7 +460,7 @@ class DeploymentTemplateFileTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            "RELEASE-NAME-charts-dotnet-core-files",
+            "release-name-charts-dotnet-core-files",
             jmespath.search(
                 "spec.template.spec.volumes[0].secret.secretName", docs[0])
         )

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -16,21 +16,7 @@ global:
       - name: http
         containerPort: 8000
         protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /
-        port: http
-      periodSeconds: 60
-      timeoutSeconds: 15
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /
-        port: http
-      initialDelaySeconds: 20
-      periodSeconds: 10
-      timeoutSeconds: 3
-      successThreshold: 1  
+
   mockingServer:
     enabled: false
     repository: "docker.io"


### PR DESCRIPTION
## Description

Don't put a default value for probes, but add a http probe to deployment if no other was provided to ensure backward compatibility.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [-] Linked issue
- [x] Chart version bumped
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`