### PR TITLE
Canary deployments support - dotnet template chart

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -5,6 +5,6 @@ name: charts-dotnet-core
 type: application
 dependencies:
 - name: charts-core
-  version: 1.2.1
+  version: 2.0.0
   repository: "https://ecovadiscode.github.io/charts/"
-version: 2.1.4
+version: 3.0.0

--- a/charts/dotnet-core/templates/CRD/canary.yaml
+++ b/charts/dotnet-core/templates/CRD/canary.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.global.canary.enabled }}
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: {{ include "charts-dotnet-core.fullname" . }}
+  labels:
+    {{- include "charts-dotnet-core.labels" . | nindent 4 }}
+spec:
+  provider: traefik
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "charts-dotnet-core.fullname" . }}
+  autoscalerRef:
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    name: {{ include "charts-dotnet-core.fullname" . }}
+  progressDeadlineSeconds: {{ .Values.global.canary.progressDeadlineSeconds }}
+  service:
+    port: {{ .Values.global.service.port }}
+    targetPort: {{ (index .Values.global.image.ports 0).containerPort | default "http" }}
+    portDiscovery: {{ .Values.global.canary.portDiscovery.enabled }}
+  analysis:
+    {{- toYaml .Values.global.canary.analysis.settings | nindent 4}}
+    metrics:
+    - name: error-rate
+      templateRef:
+        name: error-rate-{{ include "charts-core.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+      thresholdRange:
+        max: {{ .Values.global.canary.analysis.errorRate.threshold }}
+      interval: {{ .Values.global.canary.analysis.errorRate.interval }}
+    - name: response-time
+      templateRef:
+        name: response-time-{{ include "charts-core.fullname" . }}
+        namespace: {{ .Release.Namespace }}
+      thresholdRange:
+        max: {{ .Values.global.canary.analysis.responseTime.threshold }}
+      interval: {{ .Values.global.canary.analysis.responseTime.interval }}
+    {{- if or .Values.global.canary.acceptanceTest.enabled .Values.global.canary.loadTesting.enabled .Values.global.canary.webhooks }}
+    webhooks:
+    {{- end }}
+    {{- if .Values.global.canary.acceptanceTest.enabled }}
+      - name: acceptance-test
+        type: pre-rollout
+        url: http://{{ .Values.global.canary.loadTesting.serviceName }}.{{ .Values.global.canary.loadTesting.namespace }}/
+        timeout: 10s
+        metadata:
+          type: bash
+          {{- if or (eq "443" (.Values.global.service.port | toString)) (eq "8443" (.Values.global.service.port | toString)) }}
+          cmd: "curl -k https://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}/{{ .Values.global.canary.acceptanceTest.endpoint }}"
+          {{- else }}
+          cmd: "curl http://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}/{{ .Values.global.canary.acceptanceTest.endpoint }}"
+          {{- end }}
+    {{- end }}
+    {{- if .Values.global.canary.loadTesting.enabled }}
+      - name: load-test
+        type: rollout
+        url: http://{{ .Values.global.canary.loadTesting.serviceName }}.{{ .Values.global.canary.loadTesting.namespace }}/
+        timeout: 5s
+        metadata:
+          type: cmd
+          cmd: "hey -z {{ .Values.global.canary.loadTesting.duraion }} -q {{ .Values.global.canary.loadTesting.queries }} -c {{ .Values.global.canary.loadTesting.workers }} -host {{ include "serviceHost" . }} https://{{ .Values.global.traefik.serviceName }}.{{ .Values.global.traefik.namespace }}{{ include "servicePathPrefix" . }}/{{ .Values.global.canary.loadTesting.endpoint }}"
+          logCmdOutput: "true"
+    {{- end }}
+    {{- range .Values.global.canary.webhooks }}
+      - name: {{ .name | quote }}
+        type: {{ .type }}
+        url: {{ .url }}
+        {{- if .timeout }}
+        timeout: {{ .timeout }}
+        {{- end }}
+        {{- if .metadata }}
+        metadata:
+          {{- range $key, $value := .metadata }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/dotnet-core/templates/_helpers.tpl
+++ b/charts/dotnet-core/templates/_helpers.tpl
@@ -69,7 +69,7 @@ Create the name of the service account to use
 Extract service's host and path prefix to separate values
 */}}
 {{- define "serviceHost" -}}
-{{ printf (regexFind "[a-zA-Z.-]+.com" (index .Values.global.ingressRoutes.routes 0).rule ) }}
+{{ printf (regexFind "[a-zA-Z.-]+\\.[a-zA-Z]{2,3}" (index .Values.global.ingressRoutes.routes 0).rule ) }}
 {{- end }}
 {{- define "servicePathPrefix" -}}
 {{ printf (regexFind "/[a-z/]+" (index .Values.global.ingressRoutes.routes 0).rule ) }}

--- a/charts/dotnet-core/templates/_helpers.tpl
+++ b/charts/dotnet-core/templates/_helpers.tpl
@@ -64,3 +64,13 @@ Create the name of the service account to use
 {{- default "default" .Values.global.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Extract service's host and path prefix to separate values
+*/}}
+{{- define "serviceHost" -}}
+{{ printf (regexFind "[a-zA-Z.-]+.com" (index .Values.global.ingressRoutes.routes 0).rule ) }}
+{{- end }}
+{{- define "servicePathPrefix" -}}
+{{ printf (regexFind "/[a-z/]+" (index .Values.global.ingressRoutes.routes 0).rule ) }}
+{{- end }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
-          topologyKey: failure-domain.beta.kubernetes.io/zone
+          topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:

--- a/charts/dotnet-core/templates/hpa.yaml
+++ b/charts/dotnet-core/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "charts-dotnet-core.fullname" . }}

--- a/charts/dotnet-core/templates/service.yaml
+++ b/charts/dotnet-core/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.service.enabled -}}
+{{- if and .Values.global.service.enabled (not .Values.global.canary.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -163,8 +163,15 @@ global:
 
   affinity: {}
 
-  servicemonitor:
-    enabled: false
+  monitoring:
+    servicemonitor:
+      enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first
+      # port: 9999 # scrap prometheus metrics from this port. Defaulted to .global.service.port value if not specified
+
+    # prometheus server settings for existing prometheus installation. Currently needed only for canary deployments.
+    prometheusService: prometheus-operator-kube-p-prometheus
+    prometheusPort: 9090
+    prometheusNamespace: prometheus-operator
 
   service:
     enabled: true
@@ -176,3 +183,55 @@ global:
     minReplicas: 2
     maxReplicas: 4
     targetCPUUtilizationPercentage: 70
+
+  canary:
+    enabled: true # Setting to enable or disable canary deployments with Flagger.
+
+    progressDeadlineSeconds: 90 # the maximum time in seconds for the canary deployment to make progress before it is rollback
+
+    analysis:
+      settings:
+        interval: 20s # schedule interval
+        threshold: 20 # max number of failed metric checks before rollback
+        maxWeight: 60 # max traffic percentage routed to canary (0-100)
+        stepWeight: 5 # canary traffic increment step in percentage
+      errorRate:
+        threshold: 1 # max percentage of failed requests (5xx errors)
+        interval: 5s
+      responseTime:
+        threshold: 0.5 # max response time in seconds
+        interval: 10s
+
+    portDiscovery:
+      enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
+
+    acceptanceTest:
+      enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
+      endpoint: readyz # service endpoint to do acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
+
+    loadTesting:
+      enabled: true # enable or disable load testing with Flagger load tester based on 'hey' tool.
+      endpoint: readyz # service endpoint to do acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
+      serviceName: flagger-loadtester # name of Flagger load tester k8s service
+      namespace: flagger-system # namespace of Flagger load tester k8s service
+      duraion: 6m # duration of load test
+      queries: 10 # queries per second
+      workers: 2 # number of concurrent workers
+
+    webhooks: # https://docs.flagger.app/usage/webhooks
+      # - name: "load test" # name of webhook
+      #   type: rollout # webhook type, can be: confirm-rollout, pre-rollout, rollout, confirm-traffic-increase, confirm-promotion, post-rollout, rollback, event
+      #   url: http://flagger-loadtester-service.namespace/ # webhook Url
+      #   timeout: 15s
+      #   metadata:
+      #     cmd: "hey -z 1m -q 5 -c 2 http://deployment-service-name.namespace:9898/" 
+      # - name: "send to Slack"
+      #   type: event
+      #   url: http://event-recevier.notifications/slack
+      #   metadata:
+      #     environment: "test"
+      #     cluster: "flagger-test"
+
+  traefik: # traefik settings are needed in order to run load tests for Flagger
+    serviceName: traefik-breaking-infra
+    namespace: breaking-infra

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -185,7 +185,7 @@ global:
     targetCPUUtilizationPercentage: 70
 
   canary:
-    enabled: true # Setting to enable or disable canary deployments with Flagger.
+    enabled: false # Setting to enable or disable canary deployments with Flagger.
 
     progressDeadlineSeconds: 90 # the maximum time in seconds for the canary deployment to make progress before it is rollback
 


### PR DESCRIPTION
## Description

New major version of dotnet template chart brings canary deployments support

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [x] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`