### PR TITLE
Force deploy support, other fixes

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 2.0.0
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.0
+version: 3.0.1

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -5,6 +5,6 @@ name: charts-dotnet-core
 type: application
 dependencies:
 - name: charts-core
-  version: 2.0.0
+  version: 2.0.1
   repository: "https://ecovadiscode.github.io/charts/"
 version: 3.0.1

--- a/charts/dotnet-core/templates/CRD/canary.yaml
+++ b/charts/dotnet-core/templates/CRD/canary.yaml
@@ -28,14 +28,22 @@ spec:
         name: error-rate-{{ include "charts-core.fullname" . }}
         namespace: {{ .Release.Namespace }}
       thresholdRange:
+        {{- if .Values.global.canary.forceDeploy.enabled }}
+        max: 100
+        {{- else }}
         max: {{ .Values.global.canary.analysis.errorRate.threshold }}
+        {{- end }}
       interval: {{ .Values.global.canary.analysis.errorRate.interval }}
     - name: response-time
       templateRef:
         name: response-time-{{ include "charts-core.fullname" . }}
         namespace: {{ .Release.Namespace }}
       thresholdRange:
+        {{- if .Values.global.canary.forceDeploy.enabled }}
+        max: 100
+        {{- else }}
         max: {{ .Values.global.canary.analysis.responseTime.threshold }}
+        {{- end }}
       interval: {{ .Values.global.canary.analysis.responseTime.interval }}
     {{- if or .Values.global.canary.acceptanceTest.enabled .Values.global.canary.loadTesting.enabled .Values.global.canary.webhooks }}
     webhooks:
@@ -48,9 +56,9 @@ spec:
         metadata:
           type: bash
           {{- if or (eq "443" (.Values.global.service.port | toString)) (eq "8443" (.Values.global.service.port | toString)) }}
-          cmd: "curl -k https://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}/{{ .Values.global.canary.acceptanceTest.endpoint }}"
+          cmd: "curl -k https://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}{{ .Values.global.canary.acceptanceTest.endpoint }}"
           {{- else }}
-          cmd: "curl http://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}/{{ .Values.global.canary.acceptanceTest.endpoint }}"
+          cmd: "curl http://{{ include "charts-dotnet-core.fullname" . }}-canary.{{ .Release.Namespace }}{{ .Values.global.canary.acceptanceTest.endpoint }}"
           {{- end }}
     {{- end }}
     {{- if .Values.global.canary.loadTesting.enabled }}
@@ -60,7 +68,7 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z {{ .Values.global.canary.loadTesting.duraion }} -q {{ .Values.global.canary.loadTesting.queries }} -c {{ .Values.global.canary.loadTesting.workers }} -host {{ include "serviceHost" . }} https://{{ .Values.global.traefik.serviceName }}.{{ .Values.global.traefik.namespace }}{{ include "servicePathPrefix" . }}/{{ .Values.global.canary.loadTesting.endpoint }}"
+          cmd: "hey -z {{ .Values.global.canary.loadTesting.duraion }} -q {{ .Values.global.canary.loadTesting.queries }} -c {{ .Values.global.canary.loadTesting.workers }} -host {{ include "serviceHost" . }} https://{{ .Values.global.traefik.serviceName }}.{{ .Values.global.traefik.namespace }}{{ include "servicePathPrefix" . }}{{ .Values.global.canary.loadTesting.endpoint }}"
           logCmdOutput: "true"
     {{- end }}
     {{- range .Values.global.canary.webhooks }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -60,8 +60,12 @@ spec:
           args: {{- toYaml .Values.global.image.args | nindent 12 }}
           {{- end }}
           ports:
-            {{- toYaml .Values.global.image.ports | nindent 12 }}
-          
+          {{- toYaml .Values.global.image.ports | nindent 12 }}
+          {{- if .Values.global.monitoring.metrics.enabled }}
+            - containerPort: {{ .Values.global.monitoring.metrics.port }}
+              name: metrics
+              protocol: TCP
+          {{- end }}
           livenessProbe:
           {{- if .Values.global.image.livenessProbe }}
           {{- toYaml .Values.global.image.livenessProbe | nindent 12 }}

--- a/charts/dotnet-core/templates/service.yaml
+++ b/charts/dotnet-core/templates/service.yaml
@@ -12,6 +12,11 @@ spec:
       targetPort: {{ (index .Values.global.image.ports 0).containerPort | default "http" }} 
       protocol: TCP
       name: {{ (index .Values.global.image.ports 0).name | default "http" }}
+    {{- if .Values.global.monitoring.metrics.enabled }}
+    - port: {{ .Values.global.monitoring.metrics.port }}
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "charts-dotnet-core.selectorLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -203,15 +203,15 @@ global:
         interval: 10s
 
     portDiscovery:
-      enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
+      enabled: true # [bool] auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
 
     acceptanceTest:
-      enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
-      endpoint: readyz # service endpoint to do acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
+      enabled: true # [bool] enable or disable acceptance test. Canary rollout will not happen if it fails.
+      endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
 
     loadTesting:
-      enabled: true # enable or disable load testing with Flagger load tester based on 'hey' tool.
-      endpoint: readyz # service endpoint to do acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
+      enabled: #{canaryLoadTestingEnabled}# # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.
+      endpoint: /readyz # service endpoint to do a load test. Readiness health probe is default, so load test Url looks like http://service.namespace/readyz/ by default.
       serviceName: flagger-loadtester # name of Flagger load tester k8s service
       namespace: flagger-system # namespace of Flagger load tester k8s service
       duraion: 6m # duration of load test
@@ -232,6 +232,9 @@ global:
       #     environment: "test"
       #     cluster: "flagger-test"
 
+    forceDeploy:
+      enabled: false # [bool] enable to bypass error-rate and latency metrics. They are set == 100 if enabled.
+
   traefik: # traefik settings are needed in order to run load tests for Flagger
-    serviceName: traefik-breaking-infra
-    namespace: breaking-infra
+    serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible
+    namespace: #{traefikServiceNamespace}# # namespace where traefik k8s service is installed

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -165,11 +165,11 @@ global:
 
   monitoring:
     metrics:
-      enabled: false
+      enabled: false # enable if service exposes metrics, so they will be routed to k8s service on specified port, allowing network policy will be created etc
       port: 9100
       path: /metrics
     servicemonitor:
-      enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first
+      enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first. NOTE: global.monitoring.metrics should be enabled as well.
 
     # prometheus server settings for existing prometheus installation. Currently needed only for canary deployments.
     prometheusService: prometheus-operator-kube-p-prometheus
@@ -206,10 +206,10 @@ global:
         interval: 10s
 
     portDiscovery:
-      enabled: true # [bool] auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
+      enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
 
     acceptanceTest:
-      enabled: true # [bool] enable or disable acceptance test. Canary rollout will not happen if it fails.
+      enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
       endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
 
     loadTesting:
@@ -236,7 +236,7 @@ global:
       #     cluster: "flagger-test"
 
     forceDeploy:
-      enabled: false # [bool] enable to bypass error-rate and latency metrics. They are set == 100 if enabled.
+      enabled: false # enable to bypass error-rate and latency metrics. They are set == 100 if enabled.
 
   traefik: # traefik settings are needed in order to run load tests for Flagger
     serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -164,9 +164,12 @@ global:
   affinity: {}
 
   monitoring:
+    metrics:
+      enabled: false
+      port: 9100
+      path: /metrics
     servicemonitor:
       enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first
-      # port: 9999 # scrap prometheus metrics from this port. Defaulted to .global.service.port value if not specified
 
     # prometheus server settings for existing prometheus installation. Currently needed only for canary deployments.
     prometheusService: prometheus-operator-kube-p-prometheus


### PR DESCRIPTION
## Description

- New option to do a 'force deployment', so error-rate and latency metrics will be bypassed (will be set to 100).
- Load testing webhook enable/disable switch tokenized in values.yaml, thus it is disabled by default.
- Other fixes and improvements.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`