### PR TITLE
Core chart metrics support

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/core/templates/CRD/metrictemplate.yaml
+++ b/charts/core/templates/CRD/metrictemplate.yaml
@@ -10,10 +10,10 @@ spec:
   query: |
 {{- if .Values.global.monitoring.servicemonitor.enabled }}
     100 - sum by (job) 
-      (rate(http_requests_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary",status!~"5.*"}[30s]))
+      (rate(http_requests_received_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary",status!~"5.*"}[1m]))
         / ignoring(status) group_left
     sum by (job) 
-      (rate(http_requests_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[30s])) * 100
+      (rate(http_requests_received_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m])) * 100
 {{- else }}
     100 - sum by (exported_service) 
       (rate(traefik_service_requests_total{exported_service=~"{{ .Release.Namespace }}-{{ include "charts-core.fullname" . }}-canary.*",code!~"5.*"}[2m]))
@@ -33,8 +33,8 @@ spec:
   query: |
 {{- if .Values.global.monitoring.servicemonitor.enabled }}
     sum by (job) (
-      (rate(http_request_duration_seconds_sum {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[2m] ) /
-        rate(http_request_duration_seconds_count {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[2m] )) > 0 )
+      (rate(http_request_duration_seconds_sum {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m] ) /
+        rate(http_request_duration_seconds_count {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m] )) > 0 )
 {{- else }}
     sum by (exported_service) (
       (rate(traefik_service_request_duration_seconds_sum{exported_service=~"{{ .Release.Namespace }}-{{ include "charts-core.fullname" . }}-canary.*"}[2m]) /

--- a/charts/core/templates/CRD/servicemonitor.yaml
+++ b/charts/core/templates/CRD/servicemonitor.yaml
@@ -7,13 +7,33 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}
 spec:
   endpoints:
-    - path: {{ .Values.global.monitoring.servicemonitor.metricsPath | default "/metrics" }}
-      targetPort: {{ .Values.global.monitoring.servicemonitor.port | default .Values.global.service.port }}
+    - path: {{ .Values.global.monitoring.metrics.path }}
+      targetPort: {{ .Values.global.monitoring.metrics.port }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-  jobLabel: "app.kubernetes.io/instance"
+  jobLabel: "app.kubernetes.io/name"
   selector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}
+      app.kubernetes.io/name: {{ .Release.Name }}
+{{- if .Values.global.canary.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-canary
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-canary
+spec:
+  endpoints:
+    - path: {{ .Values.global.monitoring.metrics.path }}
+      targetPort: {{ .Values.global.monitoring.metrics.port }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  jobLabel: "app.kubernetes.io/name"
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-canary
+{{- end }}
+{{- end }}

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -37,10 +37,8 @@ spec:
       ports:
         - port: 443
         - port: 80
+        - port: 8443
         - port: 8000
-{{- range .Values.global.image.ports }}
-        - port: {{ .containerPort }}
-{{- end }}
 {{- if .Values.global.monitoring.metrics.enabled }}
         - port: {{ .Values.global.monitoring.metrics.port }}  #metrics port
 {{- end }}

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -38,10 +38,8 @@ spec:
         - port: 443
         - port: 80
         - port: 8000
-{{- if .Values.global.image.ports }}
 {{- range .Values.global.image.ports }}
         - port: {{ .containerPort }}
-{{- end }}
 {{- end }}
 {{- if .Values.global.monitoring.metrics.enabled }}
         - port: {{ .Values.global.monitoring.metrics.port }}  #metrics port

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -38,8 +38,10 @@ spec:
         - port: 443
         - port: 80
         - port: 8000
+{{- if .Values.global.image.ports }}
 {{- range .Values.global.image.ports }}
         - port: {{ .containerPort }}
+{{- end }}
 {{- end }}
 {{- if .Values.global.monitoring.metrics.enabled }}
         - port: {{ .Values.global.monitoring.metrics.port }}  #metrics port

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -37,12 +37,17 @@ spec:
       ports:
         - port: 443
         - port: 80
-        - port: 8443
         - port: 8000
+{{- range .Values.global.image.ports }}
+        - port: {{ .containerPort }}
+{{- end }}
+{{- if .Values.global.monitoring.metrics.enabled }}
+        - port: {{ .Values.global.monitoring.metrics.port }}  #metrics port
+{{- end }}
 {{- if .Values.global.servicebusNetworkPolicyEnabled }}
         - port: 5671  #servicebus
 {{- end }}
-    - from: #vnet addressspace
+    - from: #vnet address space
         - ipBlock:
             cidr: {{ .Values.global.vnetCidr }}
       ports:

--- a/charts/core/templates/tests/networkpolicy_test.py
+++ b/charts/core/templates/tests/networkpolicy_test.py
@@ -20,7 +20,12 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
             values={
                 "global": {
                     "defaultNetworkPolicyEnabled": True,
-                    "redisNetworkPolicyEnabled": False
+                    "redisNetworkPolicyEnabled": False,
+                    "image": {
+                        "ports": [
+                            { "containerPort": 8000 }
+                        ]
+                    }
                 }
             },
             name=".",
@@ -34,7 +39,12 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
                 "global": {
                     "defaultNetworkPolicyEnabled": True,
                     "redisNetworkPolicyEnabled": True,
-                    "postgresNetworkPolicyEnabled": True
+                    "postgresNetworkPolicyEnabled": True,
+                    "image": {
+                        "ports": [
+                            { "containerPort": 8000 }
+                        ]
+                    }
                 }
             },
             name=".",
@@ -69,13 +79,8 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            {"port": 8443},
-            jmespath.search("spec.ingress[2].ports[2]", docs[0])
-        )
-
-        self.assertEqual(
             {"port": 8000},
-            jmespath.search("spec.ingress[2].ports[3]", docs[0])
+            jmespath.search("spec.ingress[2].ports[2]", docs[0])
         )
 
         self.assertIsNotNone(

--- a/charts/core/templates/tests/networkpolicy_test.py
+++ b/charts/core/templates/tests/networkpolicy_test.py
@@ -20,12 +20,7 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
             values={
                 "global": {
                     "defaultNetworkPolicyEnabled": True,
-                    "redisNetworkPolicyEnabled": False,
-                    "image": {
-                        "ports": [
-                            { "containerPort": 8000 }
-                        ]
-                    }
+                    "redisNetworkPolicyEnabled": False
                 }
             },
             name=".",
@@ -39,12 +34,7 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
                 "global": {
                     "defaultNetworkPolicyEnabled": True,
                     "redisNetworkPolicyEnabled": True,
-                    "postgresNetworkPolicyEnabled": True,
-                    "image": {
-                        "ports": [
-                            { "containerPort": 8000 }
-                        ]
-                    }
+                    "postgresNetworkPolicyEnabled": True
                 }
             },
             name=".",
@@ -79,8 +69,13 @@ class NetworkPolicyTemplateFileTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            {"port": 8000},
+            {"port": 8443},
             jmespath.search("spec.ingress[2].ports[2]", docs[0])
+        )
+
+        self.assertEqual(
+            {"port": 8000},
+            jmespath.search("spec.ingress[2].ports[3]", docs[0])
         )
 
         self.assertIsNotNone(

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -125,9 +125,12 @@ global:
   affinity: {}
 
   monitoring:
+    metrics:
+      enabled: false
+      port: 9100
+      path: /metrics
     servicemonitor:
       enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first
-      # port: 9999 # scrap prometheus metrics from this port. Defaulted to .global.service.port value if not specified
 
     # prometheus server settings for existing prometheus installation. Currently needed only for canary deployments.
     prometheusService: prometheus-operator-kube-p-prometheus


### PR DESCRIPTION
## Description

Container metrics for prometheus support added.
Other fixes for canary deployments feature

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`