### PR TITLE
traefik settings defaulted in helpers.tpl, some default values changed

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 2.0.1
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.1
+version: 3.0.2

--- a/charts/dotnet-core/templates/CRD/canary.yaml
+++ b/charts/dotnet-core/templates/CRD/canary.yaml
@@ -68,7 +68,7 @@ spec:
         timeout: 5s
         metadata:
           type: cmd
-          cmd: "hey -z {{ .Values.global.canary.loadTesting.duraion }} -q {{ .Values.global.canary.loadTesting.queries }} -c {{ .Values.global.canary.loadTesting.workers }} -host {{ include "serviceHost" . }} https://{{ .Values.global.traefik.serviceName }}.{{ .Values.global.traefik.namespace }}{{ include "servicePathPrefix" . }}{{ .Values.global.canary.loadTesting.endpoint }}"
+          cmd: "hey -z {{ .Values.global.canary.loadTesting.duraion }} -q {{ .Values.global.canary.loadTesting.queries }} -c {{ .Values.global.canary.loadTesting.workers }} -host {{ include "serviceHost" . }} https://{{ include "traefikService" . }}.{{ include "traefikNamespace" . }}{{ include "servicePathPrefix" . }}{{ .Values.global.canary.loadTesting.endpoint }}"
           logCmdOutput: "true"
     {{- end }}
     {{- range .Values.global.canary.webhooks }}

--- a/charts/dotnet-core/templates/_helpers.tpl
+++ b/charts/dotnet-core/templates/_helpers.tpl
@@ -74,3 +74,22 @@ Extract service's host and path prefix to separate values
 {{- define "servicePathPrefix" -}}
 {{ printf (regexFind "/[a-z/]+" (index .Values.global.ingressRoutes.routes 0).rule ) }}
 {{- end }}
+
+{{/*
+Get traefik service name and namespace name
+*/}}
+{{- define "traefikService" -}}
+{{- if .Values.global.traefik.serviceName }}
+{{- .Values.global.traefik.serviceName }}
+{{- else }}
+{{- printf "traefik-%s-infra" (split "-" .Release.Namespace)._0 }}
+{{- end }}
+{{- end }}
+
+{{- define "traefikNamespace" -}}
+{{- if .Values.global.traefik.namespace }}
+{{- .Values.global.traefik.namespace }}
+{{- else }}
+{{- printf "%s-infra" (split "-" .Release.Namespace)._0 }}
+{{- end }}
+{{- end }}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -165,11 +165,11 @@ global:
 
   monitoring:
     metrics:
-      enabled: false # enable if service exposes metrics, so they will be routed to k8s service on specified port, allowing network policy will be created etc
+      enabled: true # enable if service exposes metrics, so they will be routed to k8s service on specified port, allowing network policy will be created etc
       port: 9100
       path: /metrics
     servicemonitor:
-      enabled: false # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first. NOTE: global.monitoring.metrics should be enabled as well.
+      enabled: true # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first. NOTE: global.monitoring.metrics should be enabled as well.
 
     # prometheus server settings for existing prometheus installation. Currently needed only for canary deployments.
     prometheusService: prometheus-operator-kube-p-prometheus
@@ -189,8 +189,9 @@ global:
 
   canary:
     enabled: false # Setting to enable or disable canary deployments with Flagger.
-
     progressDeadlineSeconds: 90 # the maximum time in seconds for the canary deployment to make progress before it is rollback
+    portDiscovery:
+      enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
 
     analysis:
       settings:
@@ -205,15 +206,12 @@ global:
         threshold: 0.5 # max response time in seconds
         interval: 10s
 
-    portDiscovery:
-      enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
-
     acceptanceTest:
       enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
       endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
 
     loadTesting:
-      enabled: #{canaryLoadTestingEnabled}# # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.
+      enabled: true # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.
       endpoint: /readyz # service endpoint to do a load test. Readiness health probe is default, so load test Url looks like http://service.namespace/readyz/ by default.
       serviceName: flagger-loadtester # name of Flagger load tester k8s service
       namespace: flagger-system # namespace of Flagger load tester k8s service
@@ -221,7 +219,7 @@ global:
       queries: 10 # queries per second
       workers: 2 # number of concurrent workers
 
-    webhooks: # https://docs.flagger.app/usage/webhooks
+    webhooks: [] # https://docs.flagger.app/usage/webhooks
       # - name: "load test" # name of webhook
       #   type: rollout # webhook type, can be: confirm-rollout, pre-rollout, rollout, confirm-traffic-increase, confirm-promotion, post-rollout, rollback, event
       #   url: http://flagger-loadtester-service.namespace/ # webhook Url
@@ -238,6 +236,6 @@ global:
     forceDeploy:
       enabled: false # enable to bypass error-rate and latency metrics. They are set == 100 if enabled.
 
-  traefik: # traefik settings are needed in order to run load tests for Flagger
-    serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible
-    namespace: #{traefikServiceNamespace}# # namespace where traefik k8s service is installed
+  traefik: {} # override traefik settings are needed in order to run load tests for Flagger
+  #   serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible.
+  #   namespace: #{traefikServiceNamespace}# # namespace where traefik k8s service is installed.


### PR DESCRIPTION
## Description

Traefik settings moved to helpers out of values.yaml (there is a possibility to override them from values.yaml still)
Some defaults in values.yaml are changed

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`