### PR TITLE
Update chart with new policy, bumped version

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.3
+version: 2.0.4

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -117,6 +117,11 @@ spec:
         - ipBlock:
             cidr: {{ .Values.global.vnetCidr }}
       ports:
+{{- if .Values.global.zyteProxyNetworkPolicyEnabled }}
+        - port: 8010   #Zyte Proxy
+        - port: 8011
+        - port: 8014
+{{- end }}
 {{- if .Values.global.postgresNetworkPolicyEnabled }}
         - port: 5432  #postgres
 {{- end }}

--- a/charts/core/templates/tests/networkpolicy_test.py
+++ b/charts/core/templates/tests/networkpolicy_test.py
@@ -15,6 +15,32 @@ ROOT_FOLDER = realpath(dirname(realpath(__file__)) + "/..")
 
 class NetworkPolicyTemplateFileTest(unittest.TestCase):
 
+    def test_networkpolicy_rendering_zyte(self):
+        docs = render_chart(
+            values={
+                "global": {
+                    "defaultNetworkPolicyEnabled": True,
+                    "redisNetworkPolicyEnabled": False,
+                    "zyteProxyNetworkPolicyEnabled": True
+                }
+            },
+            name=".",
+            show_only=["templates/network-policy.yaml"]
+        )
+        self.assertRegex(docs[0]["kind"], "NetworkPolicy")
+        self.assertEqual(
+            {"port": 8010},
+            jmespath.search("spec.egress[-1].ports[0]", docs[0])
+        )
+        self.assertEqual(
+            {"port": 8011},
+            jmespath.search("spec.egress[-1].ports[1]", docs[0])
+        )
+        self.assertEqual(
+            {"port": 8014},
+            jmespath.search("spec.egress[-1].ports[2]", docs[0])
+        )
+
     def test_networkpolicy_rendering(self):
         docs = render_chart(
             values={

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -58,6 +58,7 @@ global:
   allowAllInternalClusterTrafficNetworkPolicy: false
   sqlNetworkPolicyEnabled: true
   postgresNetworkPolicyEnabled: false
+  zyteProxyNetworkPolicyEnabled: false
   servicebusNetworkPolicyEnabled: true
   redisNetworkPolicyEnabled: true
   redisCidr: ""


### PR DESCRIPTION
## Description

We need a network policy to access the external Zyte proxy service.

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`