### PR TITLE
corrected default value path in deployment template, bumped version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .pytest_cache
 charts/dotnet-core/charts
 charts/dotnet-core/charts/temp*.json
+charts/dotnet-core/charts/tmp*.json

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 2.0.4
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.4
+version: 3.0.5

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           {{- if .Values.global.image.livenessProbe }}
           {{- toYaml .Values.global.image.livenessProbe | nindent 12 }}
 
+          {{- if not .Values.global.image.livenessProbe.initialDelaySeconds }}
+            initialDelaySeconds: 60
+          {{- end }}
+
           {{- if not .Values.global.image.livenessProbe.periodSeconds }}
             periodSeconds: 60
           {{- end }}
@@ -82,6 +86,10 @@ spec:
             successThreshold: 1
           {{- end }}
 
+          {{- if not .Values.global.image.livenessProbe.failureThreshold }}
+            failureThreshold: 3
+          {{- end }}
+
           {{- else }}
             httpGet:
               path: /
@@ -89,26 +97,31 @@ spec:
             periodSeconds: 60
             timeoutSeconds: 15
             successThreshold: 1
+            failureThreshold: 3
           {{- end }}
           
           readinessProbe:
           {{- if .Values.global.image.readinessProbe }}
           {{- toYaml .Values.global.image.readinessProbe | nindent 12 }}
 
-          {{- if not .Values.global.image.initialDelaySeconds }}
+          {{- if not .Values.global.image.readinessProbe.initialDelaySeconds }}
             initialDelaySeconds: 20
           {{- end }}
 
-          {{- if not .Values.global.image.periodSeconds }}
+          {{- if not .Values.global.image.readinessProbe.periodSeconds }}
             periodSeconds: 10
           {{- end }}
 
-          {{- if not .Values.global.image.timeoutSeconds }}
+          {{- if not .Values.global.image.readinessProbe.timeoutSeconds }}
             timeoutSeconds: 3
           {{- end }}
 
-          {{- if not .Values.global.image.successThreshold }}
+          {{- if not .Values.global.image.readinessProbe.successThreshold }}
             successThreshold: 1
+          {{- end }}
+
+          {{- if not .Values.global.image.readinessProbe.failureThreshold }}
+            failureThreshold: 3
           {{- end }}
 
           {{- else }}
@@ -119,9 +132,9 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 3
             successThreshold: 1
+            failureThreshold: 3
           {{- end }}
 
-            
           {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled }}
           envFrom:
           {{- if .Values.global.envVarsEnabled }}

--- a/charts/dotnet-core/templates/tests/deployment_test.py
+++ b/charts/dotnet-core/templates/tests/deployment_test.py
@@ -247,7 +247,12 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                             "httpGet": {
                                 "path": "/test/path",
                                 "port": "443"
-                            }
+                            },
+                            "periodSeconds": 42,
+                            "initialDelaySeconds": 42,
+                            "successThreshold": 42,
+                            "timeoutSeconds": 42,
+                            "failureThreshold": 42,
                         }
                     }
                 }
@@ -262,14 +267,16 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                     "path": "/test/path",
                     "port": "443"
                 },
-                "periodSeconds": 10,
-                "initialDelaySeconds": 20,
-                "successThreshold": 1,
-                "timeoutSeconds": 3
+                "periodSeconds": 42,
+                "initialDelaySeconds": 42,
+                "successThreshold": 42,
+                "timeoutSeconds": 42,
+                "failureThreshold": 42,
             },
             jmespath.search(
                 "spec.template.spec.containers[0].readinessProbe", docs[0])
         )
+
 
     def test_should_overwrite_livenessProbe_probe(self):
         docs = render_chart(
@@ -280,7 +287,12 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                             "httpGet": {
                                 "path": "/test/path",
                                 "port": "443"
-                            }
+                            },
+                            "periodSeconds": 42,
+                            "successThreshold": 42,
+                            "failureThreshold": 42,
+                            "timeoutSeconds": 42,
+                            "initialDelaySeconds": 42
                         }
                     }
                 }
@@ -295,9 +307,11 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                     "path": "/test/path",
                     "port": "443"
                 },
-                "periodSeconds": 60,
-                "successThreshold": 1,
-                "timeoutSeconds": 15
+                "initialDelaySeconds": 42,
+                "periodSeconds": 42,
+                "successThreshold": 42,
+                "failureThreshold": 42,
+                "timeoutSeconds": 42
             },
             jmespath.search(
                 "spec.template.spec.containers[0].livenessProbe", docs[0])


### PR DESCRIPTION
## Description

I found an issue where default values are not set correctly because the path to defaults was incorrect. Corrected that path and extended the tests.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [x] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`