### PR TITLE
Pod annotations in deployment spec

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 2.0.4
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.5
+version: 3.0.6

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -23,9 +23,9 @@ spec:
     metadata:
       annotations:
         checksum/appsettings-secret: {{ include (print $.Template.BasePath "/appsettings-secret.yaml") . | sha256sum }}
-    {{- with .Values.global.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- range $key,$value := .Values.global.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       labels:
         {{- include "charts-dotnet-core.labels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## Description

The way in which pod annotations are templated from values.yaml has changed. It will allow to set pod annotations from --set console command.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`