### PR TITLE
Feature/allowing env in dotnet core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 charts/dotnet-core/charts
 charts/dotnet-core/charts/temp*.json
 charts/dotnet-core/charts/tmp*.json
+venv/

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
 - name: charts-core
   version: 2.0.4
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.6
+version: 3.1.0

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
       {{- with .Values.global.additionalVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
-	    {{- end }}
+      {{- end }}
       {{- end }}
       {{- with .Values.global.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ toYaml . }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -150,12 +150,12 @@ spec:
           {{- if .Values.global.envEnabled }}
           {{- range $env := .Values.global.env }}
           {{- if $env.valueFrom }}
-          - name: {{ $env.name }}
-            valueFrom:
-              {{ $env.valueFrom | toYaml | nindent 4 }}
+            - name: {{ $env.name }}
+              valueFrom: 
+              {{- $env.valueFrom | toYaml | nindent 16 }}
           {{- else }}
-          - name: {{ $env.name }}
-            value: {{ $env.value }}
+            - name: {{ $env.name }}
+              value: {{ $env.value }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -146,6 +146,19 @@ spec:
                 name: "{{ include "charts-dotnet-core.fullname" . }}-secure"
           {{- end }}
           {{- end }}
+          env:
+          {{- if .Values.global.envEnabled }}
+          {{- range $env := .Values.global.env }}
+          {{- if $env.valueFrom }}
+          - name: {{ $env.name }}
+            valueFrom:
+              {{ $env.valueFrom | toYaml | nindent 4 }}
+          {{- else }}
+          - name: {{ $env.name }}
+            value: {{ $env.value }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.global.resources | nindent 12 }}
           {{- if or .Values.global.appConfigFilesEnabled .Values.global.additionalValumesEnabled }}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -139,16 +139,7 @@ global:
   secEnvVarsEnabled: true
   secEnvVars: {}
 
-  envEnabled: true
-  env:
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
+  envEnabled: false
 
   appConfigFilesEnabled: true
   appConfigFiles:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -139,7 +139,16 @@ global:
   secEnvVarsEnabled: true
   secEnvVars: {}
 
-  envEnabled: false
+  envEnabled: true
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
 
   appConfigFilesEnabled: true
   appConfigFiles:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -139,6 +139,8 @@ global:
   secEnvVarsEnabled: true
   secEnvVars: {}
 
+  envEnabled: false
+
   appConfigFilesEnabled: true
   appConfigFiles:
     globPattern: "**.json"


### PR DESCRIPTION
## Description

Hi, 
as I pointed out in this [slack message](https://ecovadis.slack.com/archives/C04017RJPTP/p1676381401780109), I want to use the [Kubernetes Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to access k8s metadata like the namespace or node name as [environment variables](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/). This was previously not possible as this requires setting `env:` instead of `envFrom:`, i.e. not referencing a configMap. An example could be:
```
# deployment.yaml
spec:
  containers:
      env:
        - name: MY_NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName`
```

I configured the chart so setting the values
```
# values.yaml
global:
  env:
    - name: MY_NODE_NAME
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName 
```
should work now, enabling us to access k8s metadata as environment variables.
         
        
## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`