### PR TITLE
Metric template response code fix

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.4
+version: 2.0.5

--- a/charts/core/templates/CRD/metrictemplate.yaml
+++ b/charts/core/templates/CRD/metrictemplate.yaml
@@ -10,8 +10,8 @@ spec:
   query: |
 {{- if .Values.global.monitoring.servicemonitor.enabled }}
     100 - sum by (job) 
-      (rate(http_requests_received_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary",status!~"5.*"}[1m]))
-        / ignoring(status) group_left
+      (rate(http_requests_received_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary",code!~"5.*"}[1m]))
+        / ignoring(code) group_left
     sum by (job) 
       (rate(http_requests_received_total{namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m])) * 100
 {{- else }}


### PR DESCRIPTION
## Description

There is an error in metric template - response code 'status' label doesn't exist in metric 'http_requests_received_total'. It changed to proper 'code' label.

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`