### PR TITLE
Mongodb ports - adding ports for shards in cluster configuration

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.5
+version: 2.0.6

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -129,7 +129,11 @@ spec:
         - port: 1433  #mssql
 {{- end }}
 {{- if .Values.global.mongodbNetworkPolicyEnabled }}
+        - port: 1024  #mongodb shards 
+        - port: 1025
+        - port: 1026
         - port: 25015  #mongodb
+        - port: 25016
         - port: 27017
 {{- end }}
 {{- if .Values.global.lnmElasticNetworkPolicyEnabled }}


### PR DESCRIPTION
## Description

Network policy had missing ports when connecting to Atlas Mongo DB - cluster configuration - each shard works on 
port: 1024 ,1025,1026. I was causing issues 


## Chart

Select the chart that you are modifying:
- [x ] core
- [ ] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x ] Description provided
- [ ] Linked issue
- [x ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`