### PR TITLE
PDB flagger support

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.6
+version: 2.0.7

--- a/charts/core/templates/pod-disruption-budget.yaml
+++ b/charts/core/templates/pod-disruption-budget.yaml
@@ -3,9 +3,11 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "charts-core.fullname" . }}-pdb
+  labels:
+    {{- include "charts-core.labels" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.global.podDisruptionBudget.minAvailable | default 1 }}
   selector:
     matchLabels:
-      {{- include "charts-core.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "charts-core.name" . }}{{ if .Values.global.canary.enabled }}-primary{{ end }}
 {{- end -}}


### PR DESCRIPTION
## Description

This version brings support fix for PDB - it will consider -primary pods if canary is enabled

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`