### PR TITLE
Canary revert support

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -5,6 +5,6 @@ name: charts-dotnet-core
 type: application
 dependencies:
 - name: charts-core
-  version: 2.0.5
+  version: 2.0.7
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.8
+version: 3.0.9

--- a/charts/dotnet-core/templates/CRD/canary.yaml
+++ b/charts/dotnet-core/templates/CRD/canary.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "charts-dotnet-core.labels" . | nindent 4 }}
 spec:
   provider: traefik
+  revertOnDeletion: true
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -34,7 +35,7 @@ spec:
     metrics:
     - name: error-rate
       templateRef:
-        name: error-rate-{{ include "charts-core.fullname" . }}
+        name: error-rate-{{ include "charts-dotnet-core.fullname" . }}
         namespace: {{ .Release.Namespace }}
       thresholdRange:
         {{- if .Values.global.canary.forceDeploy.enabled }}
@@ -45,7 +46,7 @@ spec:
       interval: {{ .Values.global.canary.analysis.errorRate.interval }}
     - name: response-time
       templateRef:
-        name: response-time-{{ include "charts-core.fullname" . }}
+        name: response-time-{{ include "charts-dotnet-core.fullname" . }}
         namespace: {{ .Release.Namespace }}
       thresholdRange:
         {{- if .Values.global.canary.forceDeploy.enabled }}

--- a/charts/dotnet-core/templates/service.yaml
+++ b/charts/dotnet-core/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.service.enabled (not .Values.global.canary.enabled) -}}
+{{- if .Values.global.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Description

This version brings support for disabling Canary deployments without downtime.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`