### PR TITLE
Canary: Avg aggregation for response time metric in MetricTemplate

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.9
+version: 2.0.10

--- a/charts/core/templates/CRD/metrictemplate.yaml
+++ b/charts/core/templates/CRD/metrictemplate.yaml
@@ -32,11 +32,11 @@ spec:
     type: prometheus
   query: |
 {{- if and .Values.global.monitoring.servicemonitor.enabled .Values.global.monitoring.metrics.enabled }}
-    sum by (job) (
+    avg by (job) (
       (rate(http_request_duration_seconds_sum {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m] ) /
         rate(http_request_duration_seconds_count {namespace="{{ .Release.Namespace }}",job="{{ include "charts-core.fullname" . }}-canary"}[1m] )) > 0 )
 {{- else }}
-    sum by (exported_service) (
+    avg by (exported_service) (
       (rate(traefik_service_request_duration_seconds_sum{exported_service=~"{{ .Release.Namespace }}-{{ include "charts-core.fullname" . }}-canary.*"}[2m]) /
         rate(traefik_service_requests_total{exported_service=~"{{ .Release.Namespace }}-{{ include "charts-core.fullname" . }}-canary.*"}[2m])) > 0)    
 {{- end }}


### PR DESCRIPTION
## Description

Aggregation changed from sum to avg in metric template for canary deployments.

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-template
- [ ] cron-job
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`