### PR TITLE
legacy traceparent apm agent header backwards compatibility switched off

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.0.11
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.15
+version: 3.0.16

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -136,6 +136,7 @@ global:
   envVars: 
     ASPNETCORE_ENVIRONMENT: Develop
     ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /readyz, /*/*/readyz, /metrics'
+    ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER: false
 
   secEnvVarsEnabled: true
   secEnvVars: {}


### PR DESCRIPTION
## Description

Briefly describe the problem and solution.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [ ] cron-job
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`