### PR TITLE
Disable default Network Policy

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.0.1
+version: 2.0.2
 dependencies:
 - name: charts-core
-  version: 2.0.9
+  version: 2.0.11
   repository: "https://ecovadiscode.github.io/charts/"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -65,7 +65,7 @@ global:
     # readOnlyRootFilesystem: true
 
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
-  defaultNetworkPolicyEnabled: true
+  defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.0.11
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.16
+version: 3.0.17

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -86,7 +86,7 @@ global:
     # readOnlyRootFilesystem: true
 
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
-  defaultNetworkPolicyEnabled: true
+  defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true


### PR DESCRIPTION
## Description

As we are started to set network policies per-namespace instead of per-app, default value for network policy for charts is set to 'false'

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-template
- [x] cron-job
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`