### PR TITLE
cron jobs with dedicated nodepool and backofflimit

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.0.2
+version: 2.0.3
 dependencies:
 - name: charts-core
   version: 2.0.11

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -83,14 +83,14 @@ spec:
           restartPolicy: Never
           {{- with .Values.global.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.global.affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.global.tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-
+      backoffLimit: "{{ .Values.global.backoffLimit }}"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -100,9 +100,20 @@ global:
 
   nodeSelector: {}
 
-  tolerations: []
-
-  affinity: {}
+  tolerations:
+  - key: "aksjobs"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: aksjobs
+            operator: In
+            values:
+            - true
 
   podDisruptionBudget:
     enabled: false
@@ -112,3 +123,5 @@ global:
 
   ingressRoutes:
     enabled: false
+
+  backoffLimit: 2    


### PR DESCRIPTION
## Description

All aks jobs from now will be assigned to nodepool with tags aksjobs:true
backoffLimit is set to 2

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [x] cron-job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`