### PR TITLE
Additional labels support for reverse proxy chart

### DIFF
--- a/charts/app-reverse-proxy/Chart.yaml
+++ b/charts/app-reverse-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charts-app-reverse-proxy
 description: EcoVadis Helm chart for application exposed with nginx reverse proxy
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.16.0
 dependencies:
 - name: charts-core

--- a/charts/app-reverse-proxy/templates/_helpers.tpl
+++ b/charts/app-reverse-proxy/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "charts-app-reverse-proxy.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.global.additionalLabelsEnabled }}
+{{ toYaml .Values.global.additionalLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -22,6 +22,9 @@ global:
   nameOverride: ""
   fullnameOverride: ""
 
+  additionalLabelsEnabled: false
+  additionalLabels: {}
+
   resources:
     application:
       limits:


### PR DESCRIPTION
## Description

Align reverse proxy chart with all charts - add additional labels support.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [x] app-reverse-proxy
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`