### PR TITLE
core chart elastic cloud public access enabled via 9243 port

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.0.11
+version: 2.0.12

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -113,6 +113,9 @@ spec:
   {{- if .Values.global.servicebusNetworkPolicyEnabled }}
         - port: 5671  #servicebus
   {{ end }}
+  {{- if .Values.global.elasticNetworkPolicyEnabled }}
+        - port: 9243  #elasticcloud
+  {{ end }}
     - to: #vnet addressspace - mssql, servicebus
         - ipBlock:
             cidr: {{ .Values.global.vnetCidr }}


### PR DESCRIPTION
## Description

To access elastic cloud via public  url instead of via private link we need to allow public egress connection on this port

## Chart

Select the chart that you are modifying:
- [X] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [X] Description provided
- [ ] Linked issue
- [X] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`