### PR TITLE
Feature/90 allowing topologyspreadconstraint donotschedule

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.0.12
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.18
+version: 3.0.19

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -30,12 +30,13 @@ spec:
         {{- include "charts-dotnet-core.labels" . | nindent 8 }}
     spec:
       topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
+        - maxSkew: {{ .Values.global.topologySpread.maxSkew }}
+          topologyKey: {{ .Values.global.topologySpread.topologyKey }}
+          whenUnsatisfiable: {{ .Values.global.topologySpread.whenUnsatisfiable }}
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: {{ include "charts-dotnet-core.name" . }}  
+              app.kubernetes.io/name: {{ include "charts-dotnet-core.name" . }}
+
       imagePullSecrets:
         - name: "{{ .Values.global.image.imagePullSecret }}"
       {{- if .Values.global.serviceAccount.create }}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -240,3 +240,9 @@ global:
   traefik: {} # override traefik settings are needed in order to run load tests for Flagger
   #   serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible.
   #   namespace: #{traefikServiceNamespace}# # namespace where traefik k8s service is installed.
+
+  topologySpread:
+    # Defaults to trying to schedule pods evenly across availability zones
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway
+    topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
## Description

See [linked issue](https://github.com/EcovadisCode/charts/issues/90) for reference.

To optimize resource usage I want to spread my pods evenly across nodes, not just AZs. 

The values file was updated to include:
```
global:
  topologySpread:
    maxSkew: 1
    whenUnsatisfiable: ScheduleAnyway
    topologyKey: topology.kubernetes.io/zone
```
, so if someone does not explicitly add these values the deployment wont change. However, now it will be possible to set `maxSkew`, `whenUnsatisfiable` and `topologyKey`.



## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [x] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [x] Updated template tests in `${CHART}/tests/*.py`