### PR TITLE
Feature/cert secret store

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.0.12
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.19
+version: 3.0.20

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -177,11 +177,11 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-          # {{- if .Values.global.certificateSecretStoreEnabled -}}
-          # - name: ecovadis-ceritificate
-          #   mountPath: "/app/cert"
-          #   readOnly: true
-          #   {{- end }}
+          {{- if .Values.global.certificateSecretStoreEnabled }}
+          - name: ecovadis-ceritificate
+            mountPath: "/app/cert"
+            readOnly: true
+            {{- end }}
             {{- if .Values.global.additionalVolumesEnabled -}}
             {{- with .Values.global.additionalVolumesMount }}
               {{- toYaml . | nindent 10 }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -177,7 +177,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.certificateSecretStoreEnabled -}}
+          {{- if .Values.global.certificateSecretStoreEnabled -}}
           - name: ecovadis-ceritificate
             mountPath: "/app/cert"
             readOnly: true

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -177,7 +177,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{ if .Values.global.certificateSecretStoreEnabled -}}
+          {{- if .Values.global.certificateSecretStoreEnabled -}}
           - name: ecovadis-ceritificate
             mountPath: "/app/cert"
             readOnly: true

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -177,11 +177,11 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-          {{- if .Values.global.certificateSecretStoreEnabled -}}
-          - name: ecovadis-ceritificate
-            mountPath: "/app/cert"
-            readOnly: true
-            {{- end }}
+          # {{- if .Values.global.certificateSecretStoreEnabled -}}
+          # - name: ecovadis-ceritificate
+          #   mountPath: "/app/cert"
+          #   readOnly: true
+          #   {{- end }}
             {{- if .Values.global.additionalVolumesEnabled -}}
             {{- with .Values.global.additionalVolumesMount }}
               {{- toYaml . | nindent 10 }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -219,7 +219,7 @@ spec:
           readOnly: true
           volumeAttributes:
             secretProviderClass: "ecovadis-cert"
-      {{- end}}
+      {{- end }}
       {{- if .Values.global.additionalVolumesEnabled -}}
       {{- with .Values.global.additionalVolumes }}
         {{- toYaml . | nindent 6 }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -154,7 +154,7 @@ spec:
                   fieldPath: metadata.name
           resources:
             {{- toYaml .Values.global.resources | nindent 12 }}
-          {{- if or .Values.global.appConfigFilesEnabled .Values.global.additionalValumesEnabled }}
+          {{- if or .Values.global.appConfigFilesEnabled .Values.global.additionalVolumesEnabled }}
           volumeMounts:
           {{- if .Values.global.appConfigFilesEnabled -}}
           {{- $currentScope := .}}
@@ -177,7 +177,12 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.additionalValumesEnabled -}}
+            {{ if .Values.global.certificateSecretStoreEnabled -}}
+          - name: ecovadis-ceritificate
+            mountPath: "/app/cert"
+            readOnly: true
+            {{- end}}
+            {{- if .Values.global.additionalVolumesEnabled -}}
             {{- with .Values.global.additionalVolumesMount }}
               {{- toYaml . | nindent 10 }}
             {{- end }}
@@ -207,7 +212,15 @@ spec:
         secret:
           secretName: {{ include "charts-dotnet-core.fullname" . }}-files
       {{- end }}
-      {{- if .Values.global.additionalValumesEnabled -}}
+      {{ if .Values.global.certificateSecretStoreEnabled -}}
+      - name: "ecovadis-ceritificate"
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+          secretProviderClass: "ecovadis-cert"
+      {{- end}}
+      {{- if .Values.global.additionalVolumesEnabled -}}
       {{- with .Values.global.additionalVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -177,11 +177,11 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-          {{- if .Values.global.certificateSecretStoreEnabled -}}
+            {{- if .Values.global.certificateSecretStoreEnabled -}}
           - name: ecovadis-ceritificate
             mountPath: "/app/cert"
             readOnly: true
-            {{- end}}
+            {{- end }}
             {{- if .Values.global.additionalVolumesEnabled -}}
             {{- with .Values.global.additionalVolumesMount }}
               {{- toYaml . | nindent 10 }}
@@ -218,7 +218,7 @@ spec:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-          secretProviderClass: "ecovadis-cert"
+            secretProviderClass: "ecovadis-cert"
       {{- end}}
       {{- if .Values.global.additionalVolumesEnabled -}}
       {{- with .Values.global.additionalVolumes }}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -148,7 +148,9 @@ global:
     filesList: []
       #- "appsettings.json"
 
-  additionalValumesEnabled: false
+  certificateSecretStoreEnabled: true
+  
+  additionalVolumesEnabled: false
   additionalVolumes: {}
   #   - name: azurefileshare
   #     azureFile:


### PR DESCRIPTION
## Description
Resolves #45 
In order to use SecretStoreProviderClass in all services we need to add mounting by default

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] azure-functions

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`