### PR TITLE
Switch to new ACR and apply settings for ACR cache rule - dockerhub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,9 @@ Select the chart that you are modifying:
 - [ ] core
 - [ ] dotnet-core
 - [ ] cron-job
+- [ ] job
 - [ ] app-reverse-proxy
 - [ ] pact-broker
-- [ ] azure-functions
 
 ## Checklist
 - [ ] Description provided

--- a/charts/app-reverse-proxy/Chart.yaml
+++ b/charts/app-reverse-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charts-app-reverse-proxy
 description: EcoVadis Helm chart for application exposed with nginx reverse proxy
 type: application
-version: 2.2.2
+version: 2.3.0
 appVersion: 1.16.0
 dependencies:
 - name: charts-core

--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -5,19 +5,18 @@ global:
     application:
       name: appwithreverseproxy
       containerPort: 8000
-      repository: "labacreco.azurecr.io"
+      repository: "cicdcr01weuy01.azurecr.io"
       pullPolicy: IfNotPresent
       tag: "v1.0.0"
     nginx:
-      name: nginxinc/nginx-unprivileged
+      name: dockerhub/nginxinc/nginx-unprivileged
       containerPort: 8443
+      repository: "cicdcr01weuy01.azurecr.io"
       pullPolicy: IfNotPresent
-      repository: "docker.io"
       tag: "1.20"
     
   imagePullSecrets: 
-    - name: "dockerhub-pull-secret"
-    - name: "labacreco-pull-secret"
+    - name: "acr-pull-secret"
 
   nameOverride: ""
   fullnameOverride: ""

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.0.6
+version: 2.1.0
 dependencies:
 - name: charts-core
   version: 2.0.12

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -10,6 +10,7 @@ spec:
     spec:
       ttlSecondsAfterFinished: {{ .Values.global.ttlSecondsAfterFinished }}
       activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
+      backoffLimit: {{ .Values.global.backoffLimit }}
       template:
         metadata:
           labels:
@@ -93,4 +94,3 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      backoffLimit: {{ .Values.global.backoffLimit }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -5,8 +5,8 @@
 global:
   schedule: ""
   image:
-    repository: "labacreco.azurecr.io"
-    imagePullSecret: "labacreco-pull-secret" # can be labacreco-pull-secret or dockerhub-pull-secret
+    repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: "acr-pull-secret"
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: Always
@@ -28,6 +28,7 @@ global:
 
   ttlSecondsAfterFinished: 86400 # Job and all pods will be deleted after this amount of time in second, regardless its result (succeeded or failed)
   activeDeadlineSeconds: 10800 # Limit of time in second during which job can create new pods.
+  backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"
@@ -118,10 +119,8 @@ global:
   podDisruptionBudget:
     enabled: false
 
-  autoscaling:
-    enabled: false
-
   ingressRoutes:
     enabled: false
 
-  backoffLimit: 2    
+  canary:
+    enabled: false

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.0.12
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.0.20
+version: 3.1.0

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -5,8 +5,8 @@ global:
     maxUnavailable: "50%"
 
   image:
-    repository: "labacreco.azurecr.io"
-    imagePullSecret: "labacreco-pull-secret"
+    repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: "acr-pull-secret"
     name: ""
     tag: ""
     pullPolicy: IfNotPresent
@@ -19,9 +19,9 @@ global:
 
   mockingServer:
     enabled: false
-    repository: "docker.io"
-    imagePullSecret: "dockerhub-pull-secret" # can be labacreco-pull-secret or dockerhub-pull-secret
-    name: "mockserver/mockserver"
+    repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: "acr-pull-secret"
+    name: "dockerhub/mockserver/mockserver"
     tag: "5.13.2"
     pullPolicy: IfNotPresent
     envEnabled: true

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: EcoVadis public Helm chart for Pact Broker
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: 2.102.2.0
 sources:
   - https://github.com/pact-foundation/pact_broker

--- a/charts/pact-broker/README.md
+++ b/charts/pact-broker/README.md
@@ -48,7 +48,7 @@ You may notice that there are many tokens like `#{variable}#` in `values.yaml` f
 
 ### **Dockerhub pull secret**
 
-There is a special entry at `image.pullSecrets` in v`alues.yaml` file that passes secret name to k8s Deployment. This secret should contain your docker.io credentials to authenticate against docker hub registry.
+There is a special entry at `image.pullSecrets` in `values.yaml` file that passes secret name to k8s Deployment. This secret should contain your docker.io credentials to authenticate against docker hub registry.
 
 It is recommended to [create](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) and use this secret and not to use anonymous image pulling because there is an issue with dockerhub repos when you may face image pull errors from public repos.
 

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -1,11 +1,11 @@
 # -- Pact Broker image information
 image:
-  registry: docker.io # -- Pact Broker image registry
-  repository: pactfoundation/pact-broker # -- Pact Broker image repository
+  registry: cicdcr01weuy01.azurecr.io # -- Pact Broker image registry
+  repository: dockerhub/pactfoundation/pact-broker # -- Pact Broker image repository
   tag: 2.102.2.0 # -- Pact Broker image tag (immutable tags are recommended) https://hub.docker.com/r/pactfoundation/pact-broker/tags
   pullPolicy: IfNotPresent # -- Specify a imagePullPolicy
   pullSecrets: # -- Array of imagePullSecrets to allow pulling the Pact Broker image from private registries: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    - dockerhub-pull-secret # -- It is recommended to create this secret and store docker.io credentials inside. Even when we are pulling image from a public repo there are may be transient errors when pulling without imagePullSecrets.
+    - acr-pull-secret # -- It is recommended to create this secret and store docker.io credentials inside. Even when we are pulling image from a public repo there are may be transient errors when pulling without imagePullSecrets.
 
 envVars:
   PACT_BROKER_DATABASE_ADAPTER: "postgres" # -- Database engine to use.


### PR DESCRIPTION
## Description

Switching all EV charts to new ACR. All images are already there, Helm deployment is tested with those changes.
Additionally - enabling ACR cache feature for first single rule: dockerhub.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [x] cron-job
- [ ] job
- [x] app-reverse-proxy
- [x] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`