### PR TITLE
Hotfix/mongodb policy evtrek

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.1.0
+version: 2.1.1

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -122,8 +122,8 @@ spec:
          - port: 1024
           endPort: 65535  # MongoDB outside VNet
   {{- end }}
-  {{- if .Values.global.mongodbSinglePortNetworkPolicyEnabled}}
-        - port: 27017
+  {{- if .Values.global.mongodbStrictNetworkPolicyEnabled}}
+        - port: 27017  # Only open port 27017 when Strict Network Policy is enabled
   {{- end }}
     - to: #vnet addressspace - mssql, servicebus
         - ipBlock:

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -119,9 +119,12 @@ spec:
         - port: 8014
   {{- end }}
   {{- if .Values.global.mongodbNetworkPolicyEnabled}}
-        - port: 27017  # MongoDB outside VNet
+         - port: 1024
+          endPort: 65535  # MongoDB outside VNet
   {{- end }}
-
+  {{- if .Values.global.mongodbSinglePortNetworkPolicyEnabled}}
+        - port: 27017
+  {{- end }}
     - to: #vnet addressspace - mssql, servicebus
         - ipBlock:
             cidr: {{ .Values.global.vnetCidr }}
@@ -132,10 +135,6 @@ spec:
         - port: 80
         - port: 53
           protocol: UDP
-  {{- if .Values.global.mongodbNetworkPolicyEnabled }}
-        - port: 1024  # Azure hosted mongo on random port in vnet
-          endPort: 65535
-  {{- end }}
   {{- if .Values.global.eventHubNetworkPolicyEnabled }} 
         - port: 5671 # - AMQP Ports
         - port: 5672

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -53,6 +53,7 @@ global:
   elasticNamespace: develop
 
   mongodbNetworkPolicyEnabled: false
+  mongodbSinglePortNetworkPolicyEnabled: false
   automountServiceAccountToken: false
   lnmElasticNetworkPolicyEnabled: false
   allowAllInternalClusterTrafficNetworkPolicy: false

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -53,7 +53,7 @@ global:
   elasticNamespace: develop
 
   mongodbNetworkPolicyEnabled: false
-  mongodbSinglePortNetworkPolicyEnabled: false
+  mongodbStrictNetworkPolicyEnabled: false
   automountServiceAccountToken: false
   lnmElasticNetworkPolicyEnabled: false
   allowAllInternalClusterTrafficNetworkPolicy: false


### PR DESCRIPTION
## Description
In the [last PR](https://github.com/EcovadisCode/charts/pull/95) in the core charts there were two issues:

1. In the dotnet-core charts there were changes from CRLF to LF. The pipeline picked this up, but noticed that the version was not changed, so the pipeline failed
2. PLUTUS team requires all ports open for MongoDB


I have now created a new policy, i.e. `mongodbStrictNetworkPolicyEnabled` which does not open all ports, but only port 27017 to 0.0.0.0/0. Users of `mongodbNetworkPolicyEnabled` will not be affected compared to previous versions.


## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [x] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`