### PR TITLE
networkpolicy without vnet

### DIFF
--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -106,7 +106,6 @@ global:
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
   servicebusNetworkPolicyEnabled: true
-  vnetCidr: "#{vnetCidr}#"
   mongodbNetworkPolicyEnabled: false
   automountServiceAccountToken: false
 

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -45,17 +45,9 @@ spec:
   {{- if .Values.global.monitoring.metrics.enabled }}
         - port: {{ .Values.global.monitoring.metrics.port }}  #metrics port
   {{- end }}
-
-    - from: #vnet address space
-        - ipBlock:
-            cidr: {{ .Values.global.vnetCidr }}
-      ports:
-        - port: 443
-        - port: 80
   {{- if .Values.global.servicebusNetworkPolicyEnabled }}
         - port: 5671  #servicebus
   {{- end }}
-
 
   egress:
     - to: #any pod in current namespace
@@ -93,14 +85,6 @@ spec:
       ports:
         - port: 9200
   {{- end }}
-  
-    - to: #any pod in monitoring namespace
-        - namespaceSelector:
-            matchLabels:
-              name: monitoring
-      ports:
-        - port: 9200
-        - port: 8200
 
     - to: #outside world - sentry, optimizely, etc
         - ipBlock:
@@ -108,8 +92,12 @@ spec:
       ports:
         - port: 443
         - port: 80
+        - port: 8433
+        - port: 8000
         - port: 9200 #any elastic or apm outside of the cluster
         - port: 8200
+        - port: 53
+          protocol: UDP
   {{- if .Values.global.elasticNetworkPolicyEnabled }}
         - port: 9243  #elasticcloud
   {{- end }}
@@ -119,23 +107,14 @@ spec:
         - port: 8014
   {{- end }}
   {{- if .Values.global.mongodbNetworkPolicyEnabled}}
+        # Use mongodbStrictNetworkPolicy if possible to avoid opening unnecessary ports
         - port: 1024
-          endPort: 65535  # MongoDB outside VNet
+          endPort: 65535
   {{- end }}
   {{- if .Values.global.mongodbStrictNetworkPolicyEnabled}}
         - port: 27017  # Only open port 27017 when Strict Network Policy is enabled
   {{- end }}
-    - to: #vnet addressspace - mssql, servicebus
-        - ipBlock:
-            cidr: {{ .Values.global.vnetCidr }}
-      ports:
-        - port: 8433
-        - port: 8000
-        - port: 433
-        - port: 80
-        - port: 53
-          protocol: UDP
-  {{- if .Values.global.eventHubNetworkPolicyEnabled }} 
+   {{- if .Values.global.eventHubNetworkPolicyEnabled }} 
         - port: 5671 # - AMQP Ports
         - port: 5672
         - port: 9093 # - Kafka Port

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -66,7 +66,6 @@ global:
   cosmosNetworkPolicyEnabled: false
   
   redisCidr: ""
-  vnetCidr: ""
   
   service:
     enabled: true

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -35,7 +35,6 @@ global:
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
   servicebusNetworkPolicyEnabled: true
-  vnetCidr: "#{vnetCidr}#"
 
   secEnvVarsEnabled: true
   secEnvVars: {}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -100,7 +100,6 @@ global:
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
   servicebusNetworkPolicyEnabled: true
-  vnetCidr: "#{vnetCidr}#"
 
   resources: {}
     # limits:

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -32,7 +32,6 @@ global:
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
   servicebusNetworkPolicyEnabled: true
-  vnetCidr: "#{vnetCidr}#"
 
   secEnvVarsEnabled: true
   secEnvVars: {}


### PR DESCRIPTION
## Description

Briefly describe the problem and solution. Please remember to create 1 PR per 1 chart in case of dependency between them, otherwise PR gate will fail.

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`