### PR TITLE
multiple sb triggers support

### DIFF
--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.1.4
+version: 2.1.5
 dependencies:
 - name: charts-core
   version: 2.1.5

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.1.5
+version: 2.2.0
 dependencies:
 - name: charts-core
   version: 2.1.5

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -15,26 +15,28 @@ spec:
   successfulJobsHistoryLimit: {{ .Values.global.keda.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.global.keda.failedJobsHistoryLimit }}
   triggers:
-    {{- if .Values.global.keda.triggers.azureServiceBus.enabled }}
+    {{- range .Values.global.keda.triggers.azureServiceBus.triggers }}
+    {{- if .enabled }}
     - type: azure-servicebus
       authenticationRef:
         name: 
-          {{ include "charts-job.fullname" . }}-servicebus
+          {{ include "charts-job.fullname" $ }}-servicebus
       metadata:
-        {{- if .Values.global.keda.triggers.azureServiceBus.queueName }}
-        queueName: {{ .Values.global.keda.triggers.azureServiceBus.queueName | quote }}
+        {{- if .queueName }}
+        queueName: {{ .queueName | quote }}
         {{- end }}
-        {{- if .Values.global.keda.triggers.azureServiceBus.topicName }}
-        topicName: {{ .Values.global.keda.triggers.azureServiceBus.topicName | quote }}
+        {{- if .topicName }}
+        topicName: {{ .topicName | quote }}
         {{- end }}
-        {{- if .Values.global.keda.triggers.azureServiceBus.subscriptionName }}
-        subscriptionName: {{ .Values.global.keda.triggers.azureServiceBus.subscriptionName | quote }}
+        {{- if .subscriptionName }}
+        subscriptionName: {{ .subscriptionName | quote }}
         {{- end }}
-        messageCount: {{ .Values.global.keda.triggers.azureServiceBus.messageCount | quote }}
-        {{- if .Values.global.keda.triggers.azureServiceBus.activationMessageCount }}
-        activationMessageCount: {{ .Values.global.keda.triggers.azureServiceBus.activationMessageCount | quote }}
+        messageCount: {{ .messageCount | default 5 | quote }}
+        {{- if .activationMessageCount }}
+        activationMessageCount: {{ .activationMessageCount | quote }}
         {{- end }}
         cloud: AzurePublicCloud
+    {{- end }}
     {{- end }}
   jobTargetRef:
     parallelism: 5

--- a/charts/job/templates/trigger-authentication.yaml
+++ b/charts/job/templates/trigger-authentication.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.keda.triggers.azureServiceBus.enabled }}
+{{- if .Values.global.keda.triggers.azureServiceBus.triggers }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -132,12 +132,11 @@ global:
       # clientIdSecretName: Optional. Name of k8s secret containing service principal data. Default is '{{ include "charts-job.fullname" . }}-secure'
     triggers:
       azureServiceBus:
-        enabled: false            # Must be enabled. However, in order to enable this trigger, settings below must be provided.
-        queueName:                # Optional. ServiceBus Queue name
-        topicName:                # Optional. ServiceBus Topic name
-        subscriptionName:         # Optional. Required if topic is specified. ServiceBus Subscripion name
-        messageCount: 3           # Optional. Count of messages to trigger scaling out: 1 -> N. Default: 5 messages
-        activationMessageCount:   # Target value for activating the scaler: 0 -> 1. Default: 0
-        connectionStringKeyVaultSecretName: # Name of the secret in Azure Keyvault that is containing a connection string to Service Bus
-
-        
+        connectionStringKeyVaultSecretName: 'ConnectionStrings--ServiceBus' # Name of secret in Azure Keyvault that is containing a connection string to Service Bus
+        triggers:
+        - enabled: true             # Must be enabled. However, in order to enable this trigger, settings below must be provided.
+          queueName:                # Optional. ServiceBus Queue name
+          topicName:                # Optional. ServiceBus Topic name
+          subscriptionName:         # Optional. Required if topic is specified. ServiceBus Subscripion name
+          messageCount: 5           # Optional. Count of messages to trigger scaling out: 1 -> N. Default: 5 messages
+          activationMessageCount:   # Target value for activating the scaler: 0 -> 1. Default: 0


### PR DESCRIPTION
## Description

Adding support of multiple service bus triggers for single job.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [x] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`