### PR TITLE
opening port 11000 to 11999 for azure sql

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.1.5
+version: 2.1.6

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -130,6 +130,8 @@ spec:
   {{- end }}
   {{- if .Values.global.sqlNetworkPolicyEnabled }}
         - port: 1433  #mssql
+        - port: 11000  # Redirect connection policy (default)
+          endPort: 11999
   {{- end }}
   {{- if .Values.global.lnmElasticNetworkPolicyEnabled }}
         - port: 9201


### PR DESCRIPTION
## Description

Hi,
we had connection issues to the Azure SQL with the network policies. Reading about it [here](https://learn.microsoft.com/en-us/azure/azure-sql/database/connectivity-architecture?view=azuresql#connection-policy) the reason was most likely that we only opened port 1433. However, since 
**Redirect** is the default and recommended connection policy all ports in the range 11000-11999 need to be opened, not just 1433.

## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`