### PR TITLE
network policy selenium

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: charts-core
 description: A Helm chart for Kubernetes
 type: application
-version: 2.1.6
+version: 2.1.7

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -71,12 +71,6 @@ spec:
             matchLabels:
               environment: {{ (split "-" .Release.Namespace)._0 }}
   {{- end }}
-      ports:
-        - port: 8443
-        - port: 8000
-        - port: 80
-        - port: 443
-
   {{- if .Values.global.elasticNetworkPolicyEnabled }} 
     - to:
         - namespaceSelector:
@@ -85,7 +79,17 @@ spec:
       ports:
         - port: 9200
   {{- end }}
-
+  {{- if .Values.global.seleniumNetworkPolicyEnabled }}
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            name: {{ .Values.global.seleniumNamespace }}
+      ports:
+        - port: 7777
+        - port: 4442
+        - port: 4443
+    {{- end }}
+    
     - to: #outside world - sentry, optimizely, etc
         - ipBlock:
             cidr: 0.0.0.0/0

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -64,7 +64,8 @@ global:
   servicebusNetworkPolicyEnabled: true
   redisNetworkPolicyEnabled: true
   cosmosNetworkPolicyEnabled: false
-  
+  seleniumNetworkPolicyEnabled: false
+  seleniumNamespace: selenium
   redisCidr: ""
   
   service:


### PR DESCRIPTION
## Description

Two changes:
1. Make allowAllInternalClusterTrafficNetworkPolicy really allow ALL internal cluster traffic
2. Create networkpolicy for Selenium

However, currently the selenium namespace does not have a label name=selenium, so currently these changes would not work. If we apply this label though, it should.
![image](https://github.com/EcovadisCode/charts/assets/51915979/39e11070-8326-440f-b838-86a8113579ac)


## Chart

Select the chart that you are modifying:
- [x] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`