### PR TITLE
Additional parametrization for keda Job and CronJob charts

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.1.7
+version: 2.1.8
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -13,7 +13,9 @@ spec:
       activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
       backoffLimit: {{ .Values.global.backoffLimit }}
       parallelism: {{ .Values.global.parallelism }}
+      {{- if and (.Values.global.completions) (lt (int .Values.global.parallelism) 2) }}
       completions: {{ .Values.global.completions }}
+      {{- end }}
       template:
         metadata:
           labels:

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -12,6 +12,7 @@ spec:
       ttlSecondsAfterFinished: {{ .Values.global.ttlSecondsAfterFinished }}
       activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
       backoffLimit: {{ .Values.global.backoffLimit }}
+      parallelism: {{ .Values.global.parallelism }}
       template:
         metadata:
           labels:

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -13,6 +13,7 @@ spec:
       activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
       backoffLimit: {{ .Values.global.backoffLimit }}
       parallelism: {{ .Values.global.parallelism }}
+      completions: {{ .Values.global.completions }}
       template:
         metadata:
           labels:

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -4,7 +4,6 @@
 
 global:
   schedule: ""
-  concurrencyPolicy: Allow
   image:
     repository: "cicdcr01weuy01.azurecr.io"
     imagePullSecret: "acr-pull-secret"
@@ -30,6 +29,8 @@ global:
   ttlSecondsAfterFinished: 86400 # Job and all pods will be deleted after this amount of time in second, regardless its result (succeeded or failed)
   activeDeadlineSeconds: 10800 # Job completion timeout
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
+  concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. Valid values are: Allow (default), Forbid or Replace
+  parallelism: 1 # Number of pods to run in parallel
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -30,7 +30,8 @@ global:
   activeDeadlineSeconds: 10800 # Job completion timeout
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
   concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. This will allow multiple jobs to run in parallel. Valid values are: Allow (default), Forbid or Replace
-  parallelism: 1 # Number of pods to run in parallel for a single job
+  parallelism: 1 # Number of pods to run in parallel for a single job (https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)
+  completions: 1 # Number of successful completions required before marking the job as completed
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -31,7 +31,7 @@ global:
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
   concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. This will allow multiple jobs to run in parallel. Valid values are: Allow (default), Forbid or Replace
   parallelism: 1 # Number of pods to run in parallel for a single job (https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)
-  completions: 1 # Number of successful completions required before marking the job as completed
+  completions: 1 # Number of successful completions required before marking the job as completed. This will be ignored if parallelism is set to more than 1.
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -29,8 +29,8 @@ global:
   ttlSecondsAfterFinished: 86400 # Job and all pods will be deleted after this amount of time in second, regardless its result (succeeded or failed)
   activeDeadlineSeconds: 10800 # Job completion timeout
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
-  concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. Valid values are: Allow (default), Forbid or Replace
-  parallelism: 1 # Number of pods to run in parallel
+  concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. This will allow multiple jobs to run in parallel. Valid values are: Allow (default), Forbid or Replace
+  parallelism: 1 # Number of pods to run in parallel for a single job
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.2.2
+version: 2.2.3
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -39,8 +39,8 @@ spec:
     {{- end }}
     {{- end }}
   jobTargetRef:
-    parallelism: {{ .Values.global.keda.parallelism }}
-    completions: {{ .Values.global.keda.completions }}
+    parallelism: {{ .Values.global.parallelism }}
+    completions: {{ .Values.global.completions }}
     activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
     backoffLimit: {{ .Values.global.backoffLimit }}
     template:

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -40,7 +40,9 @@ spec:
     {{- end }}
   jobTargetRef:
     parallelism: {{ .Values.global.parallelism }}
+    {{- if and (.Values.global.completions) (lt (int .Values.global.parallelism) 2) }}
     completions: {{ .Values.global.completions }}
+    {{- end }}
     activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
     backoffLimit: {{ .Values.global.backoffLimit }}
     template:

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -39,8 +39,8 @@ spec:
     {{- end }}
     {{- end }}
   jobTargetRef:
-    parallelism: 5
-    completions: 1
+    parallelism: {{ .Values.global.keda.parallelism }}
+    completions: {{ .Values.global.keda.completions }}
     activeDeadlineSeconds: {{ .Values.global.activeDeadlineSeconds }}
     backoffLimit: {{ .Values.global.backoffLimit }}
     template:

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -27,6 +27,8 @@ global:
 
   activeDeadlineSeconds: 10800 # Limit of time in second during which job can create new pods.
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
+  parallelism: 1 # Number of concurrent PODS to run at the same time for single job (https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)
+  completions: 1 # Number of successful completions required before marking the job as completed
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"
@@ -125,8 +127,6 @@ global:
     pollingInterval: 30 # Polling interval in seconds
     minReplicaCount: 0 # Minimum number of JOBS to run at the same time
     maxReplicaCount: 5 # Maximum number of JOBS to run at the same time
-    parallelism: 1 # Number of concurrent PODS to run at the same time for single job
-    completions: 1 # Number of successful completions required before marking the job as completed
     successfulJobsHistoryLimit: 3 # Number of successful jobs to keep in history
     failedJobsHistoryLimit: 3 # Number of failed jobs to keep in history
     azure:

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -121,12 +121,14 @@ global:
     enabled: false
 
   keda:
-    autoscalingPaused: false
-    pollingInterval: 30
-    minReplicaCount: 0
-    maxReplicaCount: 5
-    successfulJobsHistoryLimit: 3
-    failedJobsHistoryLimit: 3
+    autoscalingPaused: false # If true, KEDA will not scale the job
+    pollingInterval: 30 # Polling interval in seconds
+    minReplicaCount: 0 # Minimum number of JOBS to run at the same time
+    maxReplicaCount: 5 # Maximum number of JOBS to run at the same time
+    parallelism: 1 # Number of concurrent PODS to run at the same time for single job
+    completions: 1 # Number of successful completions required before marking the job as completed
+    successfulJobsHistoryLimit: 3 # Number of successful jobs to keep in history
+    failedJobsHistoryLimit: 3 # Number of failed jobs to keep in history
     azure:
       clientIdSecretKey: 'AzureIdentity__ClientSecret' # Key in k8s secret containing service principal data.
       # clientIdSecretName: Optional. Name of k8s secret containing service principal data. Default is '{{ include "charts-job.fullname" . }}-secure'

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -28,7 +28,7 @@ global:
   activeDeadlineSeconds: 10800 # Limit of time in second during which job can create new pods.
   backoffLimit: 2 # Number of retries tu run a job. One retry is equal to one pod creation.
   parallelism: 1 # Number of concurrent PODS to run at the same time for single job (https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)
-  completions: 1 # Number of successful completions required before marking the job as completed
+  completions: 1 # Number of successful completions required before marking the job as completed. This will be ignored if parallelism is set to more than 1.
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"


### PR DESCRIPTION
## Description

- Adding parallelism value for keda job and CronJob, + completions value for keda job.
- Enhance description of parameters in values.yaml

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [x] cron-job
- [x] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`