### PR TITLE
secretProviderClass as variable

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.1.6
+version: 3.1.7

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: "ecovadis-cert"
+            secretProviderClass: "{{ .Values.global.certificateSecretStoreName }}"
       {{- end }}
       {{- if .Values.global.additionalVolumesEnabled -}}
       {{- with .Values.global.additionalVolumes }}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -148,6 +148,7 @@ global:
       #- "appsettings.json"
 
   certificateSecretStoreEnabled: true
+  certificateSecretStoreName: ecovadis-cert
   
   additionalVolumesEnabled: false
   additionalVolumes: {}


### PR DESCRIPTION
## Description

Secret provider as variable (do mount different secret during helm chart deployment - its required for using ecovadis.com cert)

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`
