### PR TITLE
Fix progressDeadlineSeconds for k8s deployment and Flagger

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.1.7
+version: 3.1.8

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
 {{- if not .Values.global.autoscaling.enabled }}
   replicas: {{ .Values.global.replicaCount }}
 {{- end }}
-  progressDeadlineSeconds: {{ .Values.global.progressDeadlineSeconds | default "30"}}
+  progressDeadlineSeconds: {{ .Values.global.progressDeadlineSeconds }}
   revisionHistoryLimit: {{ .Values.global.revisionHistoryLimit | default "3" }}
   minReadySeconds: {{ .Values.global.minReadySeconds | default "0"}}
   strategy:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -3,6 +3,7 @@ global:
   rollingUpdate:
     maxSurge: "50%"
     maxUnavailable: "50%"
+  progressDeadlineSeconds: 120
 
   image:
     repository: "cicdcr01weuy01.azurecr.io"
@@ -192,7 +193,7 @@ global:
 
   canary:
     enabled: false # Setting to enable or disable canary deployments with Flagger.
-    progressDeadlineSeconds: 90 # the maximum time in seconds for the canary deployment to make progress before it is rollback
+    progressDeadlineSeconds: 600 # the maximum time in seconds for the canary deployment to make progress before it is rollback
     portDiscovery:
       enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
 
@@ -200,8 +201,8 @@ global:
       settings:
         interval: 20s # schedule interval
         threshold: 20 # max number of failed metric checks before rollback
-        maxWeight: 60 # max traffic percentage routed to canary (0-100)
-        stepWeight: 5 # canary traffic increment step in percentage
+        maxWeight: 70 # max traffic percentage routed to canary (0-100)
+        stepWeight: 10 # canary traffic increment step in percentage
       errorRate:
         threshold: 1 # max percentage of failed requests (5xx errors)
         interval: 5s


### PR DESCRIPTION
## Description

- Fix error of incorrect value of both Flagger's and k8s deployment's progressDeadlineSeconds, since this setting is fixed on Flagger side in latest version.
- Adjust canary rollout analysis timings: set max percentage of traffic 60 -> 70% and weight of step 5 -> 10%.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`