### PR TITLE
Appsettings secret using data instead of stringData

### DIFF
--- a/charts/app-reverse-proxy/Chart.yaml
+++ b/charts/app-reverse-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charts-app-reverse-proxy
 description: EcoVadis Helm chart for application exposed with nginx reverse proxy
 type: application
-version: 2.4.4
+version: 2.4.5
 appVersion: 1.16.0
 dependencies:
 - name: charts-core

--- a/charts/app-reverse-proxy/templates/appsettings-secret.yaml
+++ b/charts/app-reverse-proxy/templates/appsettings-secret.yaml
@@ -5,21 +5,21 @@ metadata:
   name: {{ include "charts-app-reverse-proxy.fullname" . }}-files
   labels:
     {{- include "charts-app-reverse-proxy.labels" . | nindent 4 }}
-stringData:
+data:
 {{- if .Values.global.appConfigFiles.globPattern -}}
   {{ $currentScope := .}}
   {{ range $path, $_ :=  .Files.Glob .Values.global.appConfigFiles.globPattern }}
   {{- with $currentScope}}
 {{- $path }}: |-
-{{ .Files.Get $path | indent 4 }}
+{{ .Files.Get $path | b64enc | indent 4 }}
   {{- end }}
   {{ end }}
 {{- end -}}
 {{- if .Values.global.appConfigFiles.filesList -}}
-  {{ $files := .Files }}
+  {{- $files := .Files }}
   {{- range .Values.global.appConfigFiles.filesList }}
   {{- . }}: |-
-{{ $files.Get . | indent 4 }}
+{{ $files.Get . | b64enc | indent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.1.8
+version: 2.1.9
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/cron-job/templates/appsettings-secret.yaml
+++ b/charts/cron-job/templates/appsettings-secret.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     {{- include "charts-cron-job.labels" . | nindent 4 }}
-stringData:
+data:
 {{- if .Values.global.appConfigFiles.globPattern -}}
   {{ $currentScope := .}}
   {{ range $path, $_ :=  .Files.Glob .Values.global.appConfigFiles.globPattern }}
   {{- with $currentScope}}
 {{- $path }}: |-
-{{ .Files.Get $path | indent 4 }}
+{{ .Files.Get $path | b64enc | indent 4 }}
   {{- end }}
   {{ end }}
 {{- end -}}
@@ -20,7 +20,7 @@ stringData:
   {{- $files := .Files }}
   {{- range .Values.global.appConfigFiles.filesList }}
   {{- . }}: |-
-{{ $files.Get . | indent 4 }}
+{{ $files.Get . | b64enc | indent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.1.8
+version: 3.1.9

--- a/charts/dotnet-core/templates/appsettings-secret.yaml
+++ b/charts/dotnet-core/templates/appsettings-secret.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     {{- include "charts-dotnet-core.labels" . | nindent 4 }}
-stringData:
+data:
 {{- if .Values.global.appConfigFiles.globPattern -}}
   {{ $currentScope := .}}
   {{ range $path, $_ :=  .Files.Glob .Values.global.appConfigFiles.globPattern }}
   {{- with $currentScope}}
 {{- $path }}: |-
-{{ .Files.Get $path | indent 4 }}
+{{ .Files.Get $path | b64enc | indent 4 }}
   {{- end }}
   {{ end }}
 {{- end -}}
@@ -20,7 +20,7 @@ stringData:
   {{- $files := .Files }}
   {{- range .Values.global.appConfigFiles.filesList }}
   {{- . }}: |-
-{{ $files.Get . | indent 4 }}
+{{ $files.Get . | b64enc | indent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.2.3
+version: 2.2.4
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/job/templates/appsettings-secret.yaml
+++ b/charts/job/templates/appsettings-secret.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     {{- include "charts-job.labels" . | nindent 4 }}
-stringData:
+data:
 {{- if .Values.global.appConfigFiles.globPattern -}}
   {{ $currentScope := .}}
   {{ range $path, $_ :=  .Files.Glob .Values.global.appConfigFiles.globPattern }}
   {{- with $currentScope}}
 {{- $path }}: |-
-{{ .Files.Get $path | indent 4 }}
+{{ .Files.Get $path | b64enc | indent 4 }}
   {{- end }}
   {{ end }}
 {{- end -}}
@@ -20,7 +20,7 @@ stringData:
   {{- $files := .Files }}
   {{- range .Values.global.appConfigFiles.filesList }}
   {{- . }}: |-
-{{ $files.Get . | indent 4 }}
+{{ $files.Get . | b64enc | indent 4 }}
   {{- end }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Description

This is a mitigation for these issues with stringData:
https://github.com/kubernetes/kubernetes/issues/89938
https://github.com/helm/helm/issues/10010
https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data

Without the fix if secret is created from 2 json files (eg. input1.json and input2.json) removing input2.json file won't remove corresponding key from the secret itself - it will stay there.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [x] cron-job
- [x] job
- [x] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [x] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`