### PR TITLE
 Add settings for cron-job history limits, adjust history limits for keda jobs.

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.1.9
+version: 2.2.0
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   schedule: "{{ .Values.global.schedule }}"
   concurrencyPolicy: "{{ .Values.global.concurrencyPolicy }}"
+  successfulJobsHistoryLimit: {{ .Values.global.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.global.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: {{ .Values.global.ttlSecondsAfterFinished }}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -32,6 +32,8 @@ global:
   concurrencyPolicy: Allow # Specifies how to treat concurrent executions of a job. This will allow multiple jobs to run in parallel. Valid values are: Allow (default), Forbid or Replace
   parallelism: 1 # Number of pods to run in parallel for a single job (https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs)
   completions: 1 # Number of successful completions required before marking the job as completed. This will be ignored if parallelism is set to more than 1.
+  successfulJobsHistoryLimit: 1 # The number of successful finished jobs to retain
+  failedJobsHistoryLimit: 1 # The number of failed finished jobs to retain
 
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.2.4
+version: 2.2.5
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -127,8 +127,8 @@ global:
     pollingInterval: 30 # Polling interval in seconds
     minReplicaCount: 0 # Minimum number of JOBS to run at the same time
     maxReplicaCount: 5 # Maximum number of JOBS to run at the same time
-    successfulJobsHistoryLimit: 3 # Number of successful jobs to keep in history
-    failedJobsHistoryLimit: 3 # Number of failed jobs to keep in history
+    successfulJobsHistoryLimit: 2 # Number of successful jobs to keep in history
+    failedJobsHistoryLimit: 1 # Number of failed jobs to keep in history
     azure:
       clientIdSecretKey: 'AzureIdentity__ClientSecret' # Key in k8s secret containing service principal data.
       # clientIdSecretName: Optional. Name of k8s secret containing service principal data. Default is '{{ include "charts-job.fullname" . }}-secure'


### PR DESCRIPTION
 Add settings for cron-job history limits, adjust history limits for keda jobs.

## Description

There are no settings for cron-job, also adjusting limits for keda scaled jobs.

New default values:
cron-job:
- successful job limit: 1
- failed job limit: 1

keda-job:
- successful job limit: 2
- failed job limit: 1

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [x] cron-job
- [x] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`