### PR TITLE
Make imagePullSecret optional

### DIFF
--- a/charts/app-reverse-proxy/Chart.yaml
+++ b/charts/app-reverse-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charts-app-reverse-proxy
 description: EcoVadis Helm chart for application exposed with nginx reverse proxy
 type: application
-version: 2.4.6
+version: 2.5.0
 appVersion: 1.16.0
 dependencies:
 - name: charts-core

--- a/charts/app-reverse-proxy/templates/deployment.yaml
+++ b/charts/app-reverse-proxy/templates/deployment.yaml
@@ -20,9 +20,11 @@ spec:
       labels:
         {{- include "charts-app-reverse-proxy.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.global.imagePullSecrets }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       serviceAccountName: {{ include "charts-app-reverse-proxy.serviceAccountName" . }}
       securityContext:

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.2.0
+version: 2.3.0
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/cron-job/templates/cronjob.yaml
+++ b/charts/cron-job/templates/cronjob.yaml
@@ -23,8 +23,10 @@ spec:
           labels:
             {{- include "charts-cron-job.labels" . | nindent 12 }}
         spec:
+          {{- if .Values.global.image.imagePullSecret }}
           imagePullSecrets:
           - name: "{{ .Values.global.image.imagePullSecret }}"
+          {{- end }}
           serviceAccountName: {{ include "charts-cron-job.serviceAccountName" . }}
           automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
           containers:

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.1.9
+version: 3.2.0

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -36,9 +36,10 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: {{ include "charts-dotnet-core.name" . }}
-
+      {{- if .Values.global.image.imagePullSecret }}
       imagePullSecrets:
         - name: "{{ .Values.global.image.imagePullSecret }}"
+      {{- end }}
       {{- if .Values.global.serviceAccount.create }}
       serviceAccountName: {{ include "charts-dotnet-core.serviceAccountName" . }}
       {{- else }}

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.2.5
+version: 2.3.0
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/job/templates/job.yaml
+++ b/charts/job/templates/job.yaml
@@ -50,8 +50,10 @@ spec:
         labels:
           {{- include "charts-job.labels" . | nindent 10 }}
       spec:
+        {{- if .Values.global.image.imagePullSecret }}
         imagePullSecrets:
         - name: "{{ .Values.global.image.imagePullSecret }}"
+        {{- end }}
         serviceAccountName: {{ include "charts-job.serviceAccountName" . }}
         automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
         containers:


### PR DESCRIPTION
## Description

From this version imagePullSecret for Pod spec is becoming optional and configurable through provided values.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [x] cron-job
- [x] job
- [x] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`