### PR TITLE
dotnet-core chart: Use port name instead of numeric value

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.3.0
+version: 2.3.1
 dependencies:
 - name: charts-core
   version: 2.1.6

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -12,10 +12,6 @@ global:
     pullPolicy: IfNotPresent
     command: []
     args: []
-    ports:
-      - name: http
-        containerPort: 8000
-        protocol: TCP
 
   serviceAccount:
     # Specifies whether a service account should be created

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.2.0
+version: 3.2.1

--- a/charts/dotnet-core/templates/service.yaml
+++ b/charts/dotnet-core/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.global.service.type }}
   ports:
     - port: {{ .Values.global.service.port }}
-      targetPort: {{ (index .Values.global.image.ports 0).containerPort | default "http" }} 
+      targetPort: {{ (index .Values.global.image.ports 0).name | default "http" }} 
       protocol: TCP
       name: {{ (index .Values.global.image.ports 0).name | default "http" }}
     {{- if .Values.global.monitoring.metrics.enabled }}


### PR DESCRIPTION
## Description

- Fix for targetPort in service for workload: port name is now used instead of numeric port number
- Bonus: Removed ports from values of cron-job chart

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [x] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`