### PR TITLE
Target monitoring port of pod by name instead of port number

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.2.1
+version: 3.3.0

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -64,9 +64,7 @@ spec:
           ports:
           {{- toYaml .Values.global.image.ports | nindent 12 }}
           {{- if .Values.global.monitoring.metrics.enabled }}
-            - containerPort: {{ .Values.global.monitoring.metrics.port }}
-              name: metrics
-              protocol: TCP
+          {{- toYaml .Values.global.monitoring.metrics.ports | nindent 12 }}
           {{- end }}
           livenessProbe:
           {{- if .Values.global.image.livenessProbe }}

--- a/charts/dotnet-core/templates/service.yaml
+++ b/charts/dotnet-core/templates/service.yaml
@@ -13,9 +13,10 @@ spec:
       protocol: TCP
       name: {{ (index .Values.global.image.ports 0).name | default "http" }}
     {{- if .Values.global.monitoring.metrics.enabled }}
-    - port: {{ .Values.global.monitoring.metrics.port }}
+    - port: {{ (index .Values.global.monitoring.metrics.ports 0).containerPort }}
+      targetPort: {{ (index .Values.global.monitoring.metrics.ports 0).name | default "metrics" }}
       protocol: TCP
-      name: metrics
+      name: {{ (index .Values.global.monitoring.metrics.ports 0).name | default "metrics" }}
     {{- end }}
   selector:
     {{- include "charts-dotnet-core.selectorLabels" . | nindent 4 }}

--- a/charts/dotnet-core/templates/tests/secret_appsetting_test.py
+++ b/charts/dotnet-core/templates/tests/secret_appsetting_test.py
@@ -34,8 +34,7 @@ class SecretTemplateFileTest(unittest.TestCase):
             name=".",
             show_only=["templates/appsettings-secret.yaml"]
         )
-        print(docs)
-        self.assertIsNotNone(docs[0]["stringData"][filename1], docs[0])
-        self.assertIsNotNone(docs[0]["stringData"][filename2], docs[0])
+        self.assertIsNotNone(docs[0]["data"][filename1], docs[0])
+        self.assertIsNotNone(docs[0]["data"][filename2], docs[0])
         remove(filename1)
         remove(filename2)

--- a/charts/dotnet-core/templates/tests/secret_appsetting_test.py
+++ b/charts/dotnet-core/templates/tests/secret_appsetting_test.py
@@ -34,6 +34,7 @@ class SecretTemplateFileTest(unittest.TestCase):
             name=".",
             show_only=["templates/appsettings-secret.yaml"]
         )
+        print(docs)
         self.assertIsNotNone(docs[0]["stringData"][filename1], docs[0])
         self.assertIsNotNone(docs[0]["stringData"][filename2], docs[0])
         remove(filename1)

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -171,7 +171,10 @@ global:
   monitoring:
     metrics:
       enabled: true # enable if service exposes metrics, so they will be routed to k8s service on specified port, allowing network policy will be created etc
-      port: 9100
+      ports:
+      - name: metrics
+        containerPort: 9100
+        protocol: TCP
       path: /metrics
     servicemonitor:
       enabled: true # setting to enable or disable monitoring of service on endpoint /metrics. Service should support exporting metrics to that endpoint first. NOTE: global.monitoring.metrics should be enabled as well.


### PR DESCRIPTION
## Description

Following previous PR, doing the same for monitoring port and targeting it in Service by port name instead of port number.
Also updated structure of port values in chart's values.yaml

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`