### PR TITLE
Startup probe support

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.3.0
+version: 3.4.0

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -135,40 +135,30 @@ spec:
             failureThreshold: 3
           {{- end }}
           
+          {{- if .Values.global.image.startupProbe }}
           startupProbe:
-          { { - if .Values.global.image.startupProbe } }
-          { { - toYaml .Values.global.image.startupProbe | nindent 12 } }
+          {{- toYaml .Values.global.image.startupProbe | nindent 12 }}
 
-          { { - if not .Values.global.image.startupProbe.initialDelaySeconds } }
-          initialDelaySeconds: 40
-          { { - end } }
+          {{- if not .Values.global.image.startupProbe.initialDelaySeconds }}
+            initialDelaySeconds: 40
+          {{- end }}
 
-          { { - if not .Values.global.image.startupProbe.periodSeconds } }
-          periodSeconds: 60
-          { { - end } }
+          {{- if not .Values.global.image.startupProbe.periodSeconds }}
+            periodSeconds: 60
+          {{- end }}
 
-          { { - if not .Values.global.image.startupProbe.timeoutSeconds } }
-          timeoutSeconds: 15
-          { { - end } }
+          {{- if not .Values.global.image.startupProbe.timeoutSeconds }}
+            timeoutSeconds: 15
+          {{- end }}
 
-          { { - if not .Values.global.image.startupProbe.successThreshold } }
-          successThreshold: 1
-          { { - end } }
+          {{- if not .Values.global.image.startupProbe.successThreshold }}
+            successThreshold: 1
+          {{- end }}
 
-          { { - if not .Values.global.image.startupProbe.failureThreshold } }
-          failureThreshold: 3
-          { { - end } }
-
-          { { - else } }
-          httpGet:
-            path: /
-            port: http
-          initialDelaySeconds: 40
-          periodSeconds: 60
-          timeoutSeconds: 15
-          successThreshold: 1
-          failureThreshold: 3
-          { { - end } }
+          {{- if not .Values.global.image.startupProbe.failureThreshold }}
+            failureThreshold: 3
+          {{- end }}
+          {{- end }}
 
           {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled }}
           envFrom:
@@ -233,6 +223,8 @@ spec:
             {{- toYaml .Values.global.mockingServer.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.global.mockingServer.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.global.mockingServer.startupProbe | nindent 12 }}
           {{- if .Values.global.mockingServer.envEnabled -}}
             {{- with .Values.global.mockingServer.env }}
           env:

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -223,8 +223,10 @@ spec:
             {{- toYaml .Values.global.mockingServer.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.global.mockingServer.readinessProbe | nindent 12 }}
+          {{- if .Values.global.mockingServer.startupProbe }}
           startupProbe:
             {{- toYaml .Values.global.mockingServer.startupProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.global.mockingServer.envEnabled -}}
             {{- with .Values.global.mockingServer.env }}
           env:

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -134,6 +134,41 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           {{- end }}
+          
+          startupProbe:
+          { { - if .Values.global.image.startupProbe } }
+          { { - toYaml .Values.global.image.startupProbe | nindent 12 } }
+
+          { { - if not .Values.global.image.startupProbe.initialDelaySeconds } }
+          initialDelaySeconds: 40
+          { { - end } }
+
+          { { - if not .Values.global.image.startupProbe.periodSeconds } }
+          periodSeconds: 60
+          { { - end } }
+
+          { { - if not .Values.global.image.startupProbe.timeoutSeconds } }
+          timeoutSeconds: 15
+          { { - end } }
+
+          { { - if not .Values.global.image.startupProbe.successThreshold } }
+          successThreshold: 1
+          { { - end } }
+
+          { { - if not .Values.global.image.startupProbe.failureThreshold } }
+          failureThreshold: 3
+          { { - end } }
+
+          { { - else } }
+          httpGet:
+            path: /
+            port: http
+          initialDelaySeconds: 40
+          periodSeconds: 60
+          timeoutSeconds: 15
+          successThreshold: 1
+          failureThreshold: 3
+          { { - end } }
 
           {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled }}
           envFrom:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -46,6 +46,13 @@ global:
       periodSeconds: 3
       timeoutSeconds: 3
       successThreshold: 1
+    startupProbe:
+      tcpSocket:
+        port: http-mock
+      initialDelaySeconds: 3
+      periodSeconds: 3
+      timeoutSeconds: 3
+      successThreshold: 1
 
   nameOverride: # app name, may be the same as image.name
   
@@ -135,7 +142,7 @@ global:
   envVarsEnabled: true
   envVars: 
     ASPNETCORE_ENVIRONMENT: Develop
-    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /readyz, /*/*/readyz, /metrics'
+    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /readyz, /*/*/readyz,, /startz, /*/*/startz, /metrics'
     ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER: false
 
   secEnvVarsEnabled: true
@@ -215,7 +222,7 @@ global:
 
     acceptanceTest:
       enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
-      endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
+      endpoint: /startz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/startz/ by default.
 
     loadTesting:
       enabled: true # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -245,7 +245,7 @@ global:
 
     acceptanceTest:
       enabled: true # enable or disable acceptance test. Canary rollout will not happen if it fails.
-      endpoint: /startz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/startz/ by default.
+      endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
 
     loadTesting:
       enabled: true # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -18,6 +18,29 @@ global:
         containerPort: 8000
         protocol: TCP
 
+    ### Configure liveness, readiness and startup probes
+    ### Change scheme HTTP/HTTPS and port number, according to global.image.ports
+    # livenessProbe:
+    #   httpGet:
+    #     path: /livez
+    #     port: 8000
+    #     scheme: HTTP
+    #   initialDelaySeconds: 15
+
+    # readinessProbe:
+    #   httpGet:
+    #     path: /readyz
+    #     port: 8000
+    #     scheme: HTTP
+    #   initialDelaySeconds: 15
+    
+    # startupProbe:
+    #   httpGet:
+    #     path: /startz
+    #     port: 8000
+    #     scheme: HTTP
+    #   initialDelaySeconds: 15
+
   mockingServer:
     enabled: false
     repository: "cicdcr01weuy01.azurecr.io"

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -69,13 +69,13 @@ global:
       periodSeconds: 3
       timeoutSeconds: 3
       successThreshold: 1
-    startupProbe:
-      tcpSocket:
-        port: http-mock
-      initialDelaySeconds: 3
-      periodSeconds: 3
-      timeoutSeconds: 3
-      successThreshold: 1
+    # startupProbe:
+    #   tcpSocket:
+    #     port: http-mock
+    #   initialDelaySeconds: 3
+    #   periodSeconds: 3
+    #   timeoutSeconds: 3
+    #   successThreshold: 1
 
   nameOverride: # app name, may be the same as image.name
   


### PR DESCRIPTION
## Description

This PR bring support of startup probe for .net container and mock server container.
It is disabled by default and corresponding commented sections are added to chart's values.yaml file.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`