### PR TITLE
Added livez endpoint to ignore url for apm

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.4.0
+version: 3.5.0

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -165,7 +165,7 @@ global:
   envVarsEnabled: true
   envVars: 
     ASPNETCORE_ENVIRONMENT: Develop
-    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /readyz, /*/*/readyz,, /startz, /*/*/startz, /metrics'
+    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /readyz, /*/*/readyz, /livez, /*/*/livez, /startz, /*/*/startz, /metrics'
     ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER: false
 
   secEnvVarsEnabled: true


### PR DESCRIPTION
## Description

Added /livez to ignored urls in order to reduce apm trace logs

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`