### PR TITLE
Add second default topology spread constraint

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.7.0
+version: 3.6.0

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -6,4 +6,4 @@ dependencies:
 - name: charts-core
   version: 2.1.6
   repository: "https://ecovadiscode.github.io/charts/"
-version: 3.5.0
+version: 3.7.0

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -29,13 +29,17 @@ spec:
       labels:
         {{- include "charts-dotnet-core.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.global.topologySpread }}
       topologySpreadConstraints:
-        - maxSkew: {{ .Values.global.topologySpread.maxSkew }}
-          topologyKey: {{ .Values.global.topologySpread.topologyKey }}
-          whenUnsatisfiable: {{ .Values.global.topologySpread.whenUnsatisfiable }}
+      {{- range .Values.global.topologySpread }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: {{ include "charts-dotnet-core.name" . }}
+              app.kubernetes.io/name: {{ include "charts-dotnet-core.name" $ }}
+      {{- end }}
+      {{- end }}
       {{- if .Values.global.image.imagePullSecret }}
       imagePullSecrets:
         - name: "{{ .Values.global.image.imagePullSecret }}"

--- a/charts/dotnet-core/templates/tests/deployment_test.py
+++ b/charts/dotnet-core/templates/tests/deployment_test.py
@@ -588,6 +588,16 @@ class DeploymentTemplateFileTest(unittest.TestCase):
                             'app.kubernetes.io/name': 'charts-dotnet-core'
                         }
                     }
+                },
+                {
+                    'maxSkew': 1,
+                    'topologyKey': 'kubernetes.io/hostname',
+                    'whenUnsatisfiable': 'ScheduleAnyway',
+                    'labelSelector': {
+                        'matchLabels': {
+                            'app.kubernetes.io/name': 'charts-dotnet-core'
+                        }
+                    }
                 }
             ],
             jmespath.search("spec.template.spec.topologySpreadConstraints", docs[0]))
@@ -596,20 +606,37 @@ class DeploymentTemplateFileTest(unittest.TestCase):
     def test_topology_spread_constraint_overwritten(self):
         docs = render_chart(
             values={
-                "global": {
-                    "topologySpread": {
+            "global": {
+                "topologySpread": [
+                    {
+                        "maxSkew": 2,
+                        "whenUnsatisfiable": "ScheduleAnyway",
+                        "topologyKey": "topology.kubernetes.io/anotherzone"
+                    },
+                    {
                         "maxSkew": 2,
                         "whenUnsatisfiable": "DoNotSchedule",
-                        "topologyKey": "kubernetes.io/hostname"
+                        "topologyKey": "kubernetes.io/anotherhostname"
                     }
-                }
+                ]
+            }
             },
             name=".", show_only=["templates/deployment.yaml"])
         self.assertEqual(
             [
                 {
                     'maxSkew': 2,
-                    'topologyKey': 'kubernetes.io/hostname',
+                    'topologyKey': 'topology.kubernetes.io/anotherzone',
+                    'whenUnsatisfiable': 'ScheduleAnyway',
+                    'labelSelector': {
+                        'matchLabels': {
+                            'app.kubernetes.io/name': 'charts-dotnet-core'
+                        }
+                    }
+                },
+                {
+                    'maxSkew': 2,
+                    'topologyKey': 'kubernetes.io/anotherhostname',
                     'whenUnsatisfiable': 'DoNotSchedule',
                     'labelSelector': {
                         'matchLabels': {

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -277,8 +277,11 @@ global:
   #   serviceName: #{traefikServiceName}# # k8s service name under which traefik is accessible.
   #   namespace: #{traefikServiceNamespace}# # namespace where traefik k8s service is installed.
 
+  # Defaults to trying to schedule pods evenly across availability zones and node hostnames
   topologySpread:
-    # Defaults to trying to schedule pods evenly across availability zones
+  - topologyKey: topology.kubernetes.io/zone
     maxSkew: 1
     whenUnsatisfiable: ScheduleAnyway
-    topologyKey: topology.kubernetes.io/zone
+  - topologyKey: kubernetes.io/hostname
+    maxSkew: 1
+    whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
## Description

Adding second default topology spread constraint as it will help distribute pods across nodes more equally if possible.
In case of unsatisfying any constraint, pod will be scheduled anyway. 

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`