### PR TITLE
chore: remove elastic related config

### DIFF
--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -100,6 +100,8 @@ global:
   defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
+  elasticNetworkPolicyEnabled: true
+  elasticNamespace: #{elasticNamespace}#
   redisNetworkPolicyEnabled: false
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true

--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -100,8 +100,6 @@ global:
   defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
-  elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
   redisNetworkPolicyEnabled: false
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true

--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -101,7 +101,6 @@ global:
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
   redisNetworkPolicyEnabled: false
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -77,15 +77,6 @@ spec:
         - port: 80
         - port: 443
 
-  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              name: {{ .Values.global.elasticNamespace }}
-      ports:
-        - port: 9200
-  {{- end }}
-
     - to: #outside world - sentry, optimizely, etc
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -94,13 +85,9 @@ spec:
         - port: 80
         - port: 8433
         - port: 8000
-        - port: 9200 #any elastic or apm outside of the cluster
         - port: 8200
         - port: 53
           protocol: UDP
-  {{- if .Values.global.elasticNetworkPolicyEnabled }}
-        - port: 9243  #elasticcloud
-  {{- end }}
   {{- if .Values.global.postgresNetworkPolicyEnabled }}
         - port: 5432  #postgres
   {{- end }}  
@@ -133,13 +120,7 @@ spec:
         - port: 11000  # Redirect connection policy (default)
           endPort: 11999
   {{- end }}
-  {{- if .Values.global.lnmElasticNetworkPolicyEnabled }}
-        - port: 9201
-  {{- end }}
   {{- if .Values.global.cosmosNetworkPolicyEnabled }}
         - port: 10255
-  {{- end }}
-  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
-        - port: 9243 #elastic cloud
   {{- end }}
 {{- end -}}

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -77,15 +77,6 @@ spec:
         - port: 80
         - port: 443
 
-  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              name: {{ .Values.global.elasticNamespace }}
-      ports:
-        - port: 9200
-  {{- end }}
-
     - to: #outside world - sentry, optimizely, etc
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -94,7 +85,6 @@ spec:
         - port: 80
         - port: 8433
         - port: 8000
-        - port: 9200 #any elastic or apm outside of the cluster
         - port: 8200
         - port: 53
           protocol: UDP
@@ -138,8 +128,5 @@ spec:
   {{- end }}
   {{- if .Values.global.cosmosNetworkPolicyEnabled }}
         - port: 10255
-  {{- end }}
-  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
-        - port: 9243 #elastic cloud
   {{- end }}
 {{- end -}}

--- a/charts/core/templates/network-policy.yaml
+++ b/charts/core/templates/network-policy.yaml
@@ -77,6 +77,15 @@ spec:
         - port: 80
         - port: 443
 
+  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              name: {{ .Values.global.elasticNamespace }}
+      ports:
+        - port: 9200
+  {{- end }}
+
     - to: #outside world - sentry, optimizely, etc
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -85,9 +94,13 @@ spec:
         - port: 80
         - port: 8433
         - port: 8000
+        - port: 9200 #any elastic or apm outside of the cluster
         - port: 8200
         - port: 53
           protocol: UDP
+  {{- if .Values.global.elasticNetworkPolicyEnabled }}
+        - port: 9243  #elasticcloud
+  {{- end }}
   {{- if .Values.global.postgresNetworkPolicyEnabled }}
         - port: 5432  #postgres
   {{- end }}  
@@ -120,7 +133,13 @@ spec:
         - port: 11000  # Redirect connection policy (default)
           endPort: 11999
   {{- end }}
+  {{- if .Values.global.lnmElasticNetworkPolicyEnabled }}
+        - port: 9201
+  {{- end }}
   {{- if .Values.global.cosmosNetworkPolicyEnabled }}
         - port: 10255
+  {{- end }}
+  {{- if .Values.global.elasticNetworkPolicyEnabled }} 
+        - port: 9243 #elastic cloud
   {{- end }}
 {{- end -}}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -49,10 +49,13 @@ global:
   defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
+  elasticNetworkPolicyEnabled: true
+  elasticNamespace: develop
 
   mongodbNetworkPolicyEnabled: false
   mongodbStrictNetworkPolicyEnabled: false
   automountServiceAccountToken: false
+  lnmElasticNetworkPolicyEnabled: false
   allowAllInternalClusterTrafficNetworkPolicy: false
   sqlNetworkPolicyEnabled: true
   postgresNetworkPolicyEnabled: false

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -49,13 +49,10 @@ global:
   defaultNetworkPolicyEnabled: false
 
   #Additional Network Polices configuration
-  elasticNetworkPolicyEnabled: true
-  elasticNamespace: develop
 
   mongodbNetworkPolicyEnabled: false
   mongodbStrictNetworkPolicyEnabled: false
   automountServiceAccountToken: false
-  lnmElasticNetworkPolicyEnabled: false
   allowAllInternalClusterTrafficNetworkPolicy: false
   sqlNetworkPolicyEnabled: true
   postgresNetworkPolicyEnabled: false

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -50,8 +50,6 @@ global:
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true
-  elasticNamespace: develop
-
   mongodbNetworkPolicyEnabled: false
   mongodbStrictNetworkPolicyEnabled: false
   automountServiceAccountToken: false

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -68,10 +68,6 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
-  #Additional Network Polices configuration
-  elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
-
   automountServiceAccountToken: false
 
   resources: {}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -68,6 +68,10 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
+  #Additional Network Polices configuration
+  elasticNetworkPolicyEnabled: true
+  elasticNamespace: #{elasticNamespace}#
+
   automountServiceAccountToken: false
 
   resources: {}

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -70,7 +70,6 @@ global:
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
 
   automountServiceAccountToken: false
 

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -121,7 +121,6 @@ global:
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
 
   mongodbNetworkPolicyEnabled: false
   eventHubNetworkPolicyEnabled: false

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -119,14 +119,9 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
-  #Additional Network Polices configuration
-  elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
-
   mongodbNetworkPolicyEnabled: false
   eventHubNetworkPolicyEnabled: false
   automountServiceAccountToken: false
-  lnmElasticNetworkPolicyEnabled: false
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
@@ -165,8 +160,6 @@ global:
   envVarsEnabled: true
   envVars: 
     ASPNETCORE_ENVIRONMENT: Develop
-    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /metrics'
-    ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER: false
 
   secEnvVarsEnabled: true
   secEnvVars: {}

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -119,9 +119,14 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
+  #Additional Network Polices configuration
+  elasticNetworkPolicyEnabled: true
+  elasticNamespace: #{elasticNamespace}#
+
   mongodbNetworkPolicyEnabled: false
   eventHubNetworkPolicyEnabled: false
   automountServiceAccountToken: false
+  lnmElasticNetworkPolicyEnabled: false
   redisNetworkPolicyEnabled: true
   redisCidr: "#{redisCidr}#"
   sqlNetworkPolicyEnabled: true
@@ -160,6 +165,8 @@ global:
   envVarsEnabled: true
   envVars: 
     ASPNETCORE_ENVIRONMENT: Develop
+    ELASTIC_APM_TRANSACTION_IGNORE_URLS: '/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2, /metrics'
+    ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER: false
 
   secEnvVarsEnabled: true
   secEnvVars: {}

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -67,10 +67,6 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
-  #Additional Network Polices configuration
-  elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
-
   automountServiceAccountToken: false
 
   resources: {}

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -69,7 +69,6 @@ global:
 
   #Additional Network Polices configuration
   elasticNetworkPolicyEnabled: true
-  elasticNamespace: #{elasticNamespace}#
 
   automountServiceAccountToken: false
 

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -67,6 +67,10 @@ global:
   #Automates creation of default network policy, which is responsible for handling traffic between pod - service - traefik 
   defaultNetworkPolicyEnabled: false
 
+  #Additional Network Polices configuration
+  elasticNetworkPolicyEnabled: true
+  elasticNamespace: #{elasticNamespace}#
+
   automountServiceAccountToken: false
 
   resources: {}


### PR DESCRIPTION
## Description

Remove elastic related config which is not anymore used in kubernetes deployment

## Chart

Select the chart that you are modifying:
- [x] core
- [x] dotnet-core
- [x] cron-job
- [x] job
- [x] app-reverse-proxy
- [ ] pact-broker

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`