### PR TITLE
Refactored sidecars containers attachment

### DIFF
--- a/charts/ado-build-agents/Chart.yaml
+++ b/charts/ado-build-agents/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart with Keda scalable Azure Devops build agent for Kubernetes
 name: charts-ado-build-agents
-version: 1.2.0
+version: 1.3.0
 appVersion: "1.0"

--- a/charts/ado-build-agents/templates/scalejob-staging.yaml
+++ b/charts/ado-build-agents/templates/scalejob-staging.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.staging.enabled }}
+{{- if .Values.agent.staging.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -11,24 +11,36 @@ spec:
     template:
       metadata:
         annotations:
+          {{- if .Values.sidecarContainers.buildkit.enabled }}
           container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
+          {{- end }}
+          container.apparmor.security.beta.kubernetes.io/{{ .Values.buildAgentName }}-staging: {{ .Values.agent.apparmor }}
         labels:
           azure.workload.identity/use: "true"
       spec:
+        # For now it's explicitedy set to true to avoid issues when it becomes false by default in future kubernetes versions
+        hostUsers: true
         shareProcessNamespace: true
         serviceAccountName: "svc-acc-{{ .Values.buildAgentName }}"
         restartPolicy: Never
         terminationGracePeriodSeconds: 3600
         volumes:
+        {{- if .Values.sidecarContainers.docker.enabled }}
+          - name: dind-certs
+            emptyDir: {}
+        {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
           - name: buildkitd-certs
             emptyDir: {}
           - name: buildkitd-workspace
             emptyDir: {}
+        {{- end }}
         nodeSelector:
           pool: "{{ .Values.aks.agentPool }}"
         {{- if .Values.aks.sysbox.enabled }}
         runtimeClassName: "sysbox-runc-{{ .Values.buildAgentName }}"
         {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
         initContainers:
         - name: generate-mtls-cert
           image: busybox:1.37
@@ -48,23 +60,48 @@ spec:
           volumeMounts:
             - name: buildkitd-certs
               mountPath: /certs
+        {{- end }}
         containers:
-        - name: "{{ .Values.buildAgentName }}-staging"
-          image: {{ .Values.devops.ACR_NAME }}/{{ .Values.staging.stagingImageName }}:{{ .Values.staging.stagingImageVersion }}
-          imagePullPolicy: IfNotPresent
+        {{- if .Values.sidecarContainers.docker.enabled }}
+        - name: dind
+          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
           securityContext:
-            allowPrivilegeEscalation: true
-            privileged: false
-            capabilities:
-              add:
-                - SYS_PTRACE
-                - KILL
+            privileged: true
+          env: 
+            - name: DOCKER_TLS_CERTDIR
+              value: /dind-certs
+          volumeMounts:
+            - mountPath: /dind-certs
+              name: dind-certs
+        {{- end }}
+        - name: "{{ .Values.buildAgentName }}-staging"
+          image: {{ .Values.devops.ACR_NAME }}/{{ .Values.agent.staging.imageName }}:{{ .Values.agent.staging.imageVersion }}
+          imagePullPolicy: IfNotPresent
+          {{- with .Values.agent.securityContext }}
+          securityContext:
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: {{ .Values.aks.memoryRequest }}
             limits:
               memory: {{ .Values.aks.memoryLimit }}
           env:
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2376"
+            - name: DOCKER_CERT_PATH
+              value: "/dind-certs/client"
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            {{- end }}
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: DOCKER_BACKEND
+              value: "DOCKER"
+            {{- else }}
+            - name: DOCKER_BACKEND
+              value: "BUILDKIT"
+            {{- end }}
             - name: AZP_URL
               valueFrom:
                 secretKeyRef:
@@ -81,11 +118,19 @@ spec:
                   name: "azdevops-{{ .Values.buildAgentName }}"
                   key: ACR_NAME
           volumeMounts:
+            {{- if .Values.sidecarContainers.buildkit.enabled }}
             - name: buildkitd-certs
               mountPath: /certs
               readOnly: true
+            {{- end}}
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: dind-certs
+              mountPath: /dind-certs
+              readOnly: true
+            {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
         - name: buildkitd
-          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/buildkit:v0.21.1-rootless
+          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -140,6 +185,7 @@ spec:
               readOnly: true
             - name: buildkitd-workspace
               mountPath: /home/user/.local/share/buildkit
+        {{- end }}
         tolerations:
         - key: "pool"
           operator: "Equal"

--- a/charts/ado-build-agents/templates/scalejob.yaml
+++ b/charts/ado-build-agents/templates/scalejob.yaml
@@ -10,24 +10,36 @@ spec:
     template:
       metadata:
         annotations:
+          {{- if .Values.sidecarContainers.buildkit.enabled }}
           container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
+          {{- end }}
+          container.apparmor.security.beta.kubernetes.io/{{ .Values.buildAgentName }}: {{ .Values.agent.apparmor }}
         labels:
           azure.workload.identity/use: "true"
       spec:
+        # For now it's explicitedy set to true to avoid issues when it becomes false by default in future kubernetes versions
+        hostUsers: true
         shareProcessNamespace: true
         serviceAccountName: "svc-acc-{{ .Values.buildAgentName }}"
         restartPolicy: Never
         terminationGracePeriodSeconds: 3600
         volumes:
+        {{- if .Values.sidecarContainers.docker.enabled }}
+          - name: dind-certs
+            emptyDir: {}
+        {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
           - name: buildkitd-certs
             emptyDir: {}
           - name: buildkitd-workspace
             emptyDir: {}
+        {{- end }}
         nodeSelector:
           pool: "{{ .Values.aks.agentPool }}"
         {{- if .Values.aks.sysbox.enabled }}
         runtimeClassName: "sysbox-runc-{{ .Values.buildAgentName }}"
         {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
         initContainers:
         - name: generate-mtls-cert
           image: busybox:1.37
@@ -47,23 +59,48 @@ spec:
           volumeMounts:
             - name: buildkitd-certs
               mountPath: /certs
+        {{- end }}
         containers:
-        - name: {{ .Values.buildAgentName }}
-          image: {{ .Values.devops.ACR_NAME }}/{{ .Values.image.imageName }}:{{ .Values.image.version }}
-          imagePullPolicy: IfNotPresent
+        {{- if .Values.sidecarContainers.docker.enabled }}
+        - name: dind
+          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
           securityContext:
-            allowPrivilegeEscalation: true
-            privileged: false
-            capabilities:
-              add:
-                - SYS_PTRACE
-                - KILL
+            privileged: true
+          env: 
+            - name: DOCKER_TLS_CERTDIR
+              value: /dind-certs
+          volumeMounts:
+            - mountPath: /dind-certs
+              name: dind-certs
+        {{- end }}
+        - name: {{ .Values.buildAgentName }}
+          image: {{ .Values.devops.ACR_NAME }}/{{ .Values.agent.primary.imageName }}:{{ .Values.agent.primary.imageVersion }}
+          imagePullPolicy: IfNotPresent
+          {{- with .Values.agent.securityContext }}
+          securityContext:
+          {{ toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: {{ .Values.aks.memoryRequest }}
             limits:
               memory: {{ .Values.aks.memoryLimit }}
           env:
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2376"
+            - name: DOCKER_CERT_PATH
+              value: "/dind-certs/client"
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            {{- end }}
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: DOCKER_BACKEND
+              value: "DOCKER"
+            {{- else }}
+            - name: DOCKER_BACKEND
+              value: "BUILDKIT"
+            {{- end }}
             - name: AZP_URL
               valueFrom:
                 secretKeyRef:
@@ -80,11 +117,19 @@ spec:
                   name: "azdevops-{{ .Values.buildAgentName }}"
                   key: ACR_NAME
           volumeMounts:
+            {{- if .Values.sidecarContainers.buildkit.enabled }}
             - name: buildkitd-certs
               mountPath: /certs
               readOnly: true
+            {{- end}}
+            {{- if .Values.sidecarContainers.docker.enabled }}
+            - name: dind-certs
+              mountPath: /dind-certs
+              readOnly: true
+            {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
         - name: buildkitd
-          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/buildkit:v0.21.1-rootless
+          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000
@@ -139,6 +184,7 @@ spec:
               readOnly: true
             - name: buildkitd-workspace
               mountPath: /home/user/.local/share/buildkit
+        {{- end }}
         tolerations:
         - key: "pool"
           operator: "Equal"

--- a/charts/ado-build-agents/values.yaml
+++ b/charts/ado-build-agents/values.yaml
@@ -28,20 +28,35 @@ devops:
   # Azure Container Registry name
   ACR_NAME: "myazacr.azurecr.io"
 
-image:
-  # Image name to be used for the build agent
-  imageName: build-agent-1
-  # Image version to be used for the build agent
-  version: 1.0.0
+agent:
+  primary:
+    # Image name to be used for the main build agent
+    imageName: build-agent-1
+    # Image version to be used for the main build agent
+    imageVersion: 1.0.0
+  staging:
+    enabled: false
+    # Image name to be used for the secondary/staging build agent
+    imageName: build-agent-1-staging
+    # Image version to be used for the secondary/staging build agent
+    imageVersion: 1.0.0
+  # Security context object attached to build agent container
+  securityContext:
+    privileged: false
+  # Apparmor profile to be used for the build agent container, for now only "unconfined" is required and tested
+  apparmor: unconfined
+
+# Sidecar container that will be used from agent image. Only one sidecar should be enabled at a time. Rootless docker is not yet tested.
+sidecarContainers:
+  docker:
+    enabled: true
+    image: docker:dind
+  buildkit:
+    enabled: false
+    image: buildkit:v0.21.1-rootless
 
 keda:
   # Minimum number of replicas to be deployed, should be >= 1
   minReplicas: "1"
   # Maximum number of replicas to be deployed
   maxReplicas: "30"
-
-# Object controlling staging instance deployment, used for A/B deployment
-staging:
-  enabled: false
-  stagingImageName: build-agent-1-staging
-  stagingImageVersion: 1.0.0


### PR DESCRIPTION
## Description

Refactored possibility to deploy buildkit/docker sidecar containers.
Switched default to docker (podman was tested but it was flaky in testcontainers)

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [x] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`