### PR TITLE
Possibility do deploy both buildkit and docker

### DIFF
--- a/charts/ado-build-agents/Chart.yaml
+++ b/charts/ado-build-agents/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart with Keda scalable Azure Devops build agent for Kubernetes
 name: charts-ado-build-agents
-version: 1.3.0
+version: 1.4.0
 appVersion: "1.0"

--- a/charts/ado-build-agents/templates/scalejob-staging.yaml
+++ b/charts/ado-build-agents/templates/scalejob-staging.yaml
@@ -15,6 +15,9 @@ spec:
           container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
           {{- end }}
           container.apparmor.security.beta.kubernetes.io/{{ .Values.buildAgentName }}-staging: {{ .Values.agent.apparmor }}
+          {{- if .Values.sidecarContainers.docker.enabled}}
+          container.apparmor.security.beta.kubernetes.io/dind: {{ .Values.agent.apparmor }}
+          {{- end }}
         labels:
           azure.workload.identity/use: "true"
       spec:
@@ -96,11 +99,14 @@ spec:
               value: "1"
             {{- end }}
             {{- if .Values.sidecarContainers.docker.enabled }}
-            - name: DOCKER_BACKEND
-              value: "DOCKER"
-            {{- else }}
-            - name: DOCKER_BACKEND
-              value: "BUILDKIT"
+            - name: DOCKER_ENABLED
+              value: "TRUE"
+            {{- end }}
+            {{- if .Values.sidecarContainers.buildkit.enabled }}
+            - name: BUILDKIT_ENABLED
+              value: "TRUE"
+            - name: BUILDX_BUILDER
+              value: buildkitd
             {{- end }}
             - name: AZP_URL
               valueFrom:

--- a/charts/ado-build-agents/templates/scalejob.yaml
+++ b/charts/ado-build-agents/templates/scalejob.yaml
@@ -14,6 +14,9 @@ spec:
           container.apparmor.security.beta.kubernetes.io/buildkitd: unconfined
           {{- end }}
           container.apparmor.security.beta.kubernetes.io/{{ .Values.buildAgentName }}: {{ .Values.agent.apparmor }}
+          {{- if .Values.sidecarContainers.docker.enabled}}
+          container.apparmor.security.beta.kubernetes.io/dind: {{ .Values.agent.apparmor }}
+          {{- end }}
         labels:
           azure.workload.identity/use: "true"
       spec:
@@ -95,11 +98,14 @@ spec:
               value: "1"
             {{- end }}
             {{- if .Values.sidecarContainers.docker.enabled }}
-            - name: DOCKER_BACKEND
-              value: "DOCKER"
-            {{- else }}
-            - name: DOCKER_BACKEND
-              value: "BUILDKIT"
+            - name: DOCKER_ENABLED
+              value: "TRUE"
+            {{- end }}
+            {{- if .Values.sidecarContainers.buildkit.enabled }}
+            - name: BUILDKIT_ENABLED
+              value: "TRUE"
+            - name: BUILDX_BUILDER
+              value: buildkitd
             {{- end }}
             - name: AZP_URL
               valueFrom:


### PR DESCRIPTION
## Description

Briefly describe the problem and solution. Please remember to create 1 PR per 1 chart in case of dependency between them, otherwise PR gate will fail.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [x] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`