### PR TITLE
update nginx for reverseproxy and remove imagePullSecrets

### DIFF
--- a/charts/app-reverse-proxy/Chart.yaml
+++ b/charts/app-reverse-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charts-app-reverse-proxy
 description: EcoVadis Helm chart for application exposed with nginx reverse proxy
 type: application
-version: 2.9.1
+version: 2.9.2
 appVersion: 1.16.0
 dependencies:
 - name: charts-core

--- a/charts/app-reverse-proxy/templates/deployment.yaml
+++ b/charts/app-reverse-proxy/templates/deployment.yaml
@@ -20,12 +20,12 @@ spec:
       labels:
         {{- include "charts-app-reverse-proxy.labels" . | nindent 8 }}
     spec:
-      {{- if .Values.global.imagePullSecrets }}
-      {{- with .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- end }}
+      # {{- if .Values.global.imagePullSecrets }}
+      # {{- with .Values.global.imagePullSecrets }}
+      # imagePullSecrets:
+      #   {{- toYaml . | nindent 8 }}
+      # {{- end }}
+      # {{- end }}
       serviceAccountName: {{ include "charts-app-reverse-proxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}

--- a/charts/app-reverse-proxy/values.yaml
+++ b/charts/app-reverse-proxy/values.yaml
@@ -13,10 +13,10 @@ global:
       containerPort: 8443
       repository: "cicdcr01weuy01.azurecr.io"
       pullPolicy: IfNotPresent
-      tag: "alpine3.21-perl"
+      tag: "alpine3.22-perl"
     
-  imagePullSecrets: 
-    - name: "acr-pull-secret"
+  # imagePullSecrets:
+  #   - name: "acr-pull-secret"
 
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
## Description

Briefly describe the problem and solution. Please remember to create 1 PR per 1 chart in case of dependency between them, otherwise PR gate will fail.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [x] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`
-
![image](https://github.com/user-attachments/assets/2593b8f9-2858-4571-b6ea-91e36f107b94)
