### PR TITLE
Moved sidecars to init containers definition

### DIFF
--- a/charts/ado-build-agents/Chart.yaml
+++ b/charts/ado-build-agents/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart with Keda scalable Azure Devops build agent for Kubernetes
 name: charts-ado-build-agents
-version: 1.4.1
+version: 1.5.0
 appVersion: "1.0"

--- a/charts/ado-build-agents/templates/scalejob-staging.yaml
+++ b/charts/ado-build-agents/templates/scalejob-staging.yaml
@@ -64,6 +64,51 @@ spec:
             - name: buildkitd-certs
               mountPath: /certs
         {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
+        - name: buildkitd
+          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              add:
+                - SYS_PTRACE
+                - KILL
+            seccompProfile:
+              type: Unconfined
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "[CMD] Starting buildkitd...";
+              rootlesskit buildkitd \
+                --oci-worker-no-process-sandbox \
+                --addr tcp://0.0.0.0:1234 \
+                --addr unix:///run/user/1000/buildkit/buildkitd.sock \
+                --tlscacert /certs/server/ca.pem \
+                --tlscert /certs/server/cert.pem \
+                --tlskey /certs/server/key.pem
+          volumeMounts:
+            - name: buildkitd-certs
+              mountPath: /certs
+              readOnly: true
+            - name: buildkitd-workspace
+              mountPath: /home/user/.local/share/buildkit
+        {{- end }}
+        {{- if .Values.sidecarContainers.docker.enabled }}
+        - name: dind
+          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
+          restartPolicy: Always
+          securityContext:
+            privileged: true
+          env: 
+            - name: DOCKER_TLS_CERTDIR
+              value: /dind-certs
+          volumeMounts:
+            - mountPath: /dind-certs
+              name: dind-certs
+        {{- end }}
         containers:
           # PROTIP - In Keda agent container has to be first, otherwise it will not be able to read value from AZP_URL
         - name: "{{ .Values.buildAgentName }}-staging"
@@ -123,76 +168,6 @@ spec:
               mountPath: /dind-certs
               readOnly: true
             {{- end }}
-        {{- if .Values.sidecarContainers.buildkit.enabled }}
-        - name: buildkitd
-          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            capabilities:
-              add:
-                - SYS_PTRACE
-                - KILL
-            seccompProfile:
-              type: Unconfined
-          readinessProbe:
-            exec:
-              command:
-              - buildctl
-              - debug
-              - workers
-            failureThreshold: 3
-            initialDelaySeconds: 3
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 1
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              echo "[CMD] Starting buildkitd...";
-              rootlesskit buildkitd \
-                --oci-worker-no-process-sandbox \
-                --addr tcp://0.0.0.0:1234 \
-                --addr unix:///run/user/1000/buildkit/buildkitd.sock \
-                --tlscacert /certs/server/ca.pem \
-                --tlscert /certs/server/cert.pem \
-                --tlskey /certs/server/key.pem &
-              attempts=0
-              max_attempts=30
-              while ! pgrep start.sh > /dev/null; do
-                attempts=$((attempts + 1))
-                if [ $attempts -ge $max_attempts ]; then
-                  echo "[CMD] Failed to find start.sh after $max_attempts attempts. Exiting with status 1."
-                  exit 1
-                fi
-                echo "[CMD] Failed to find process start.sh from agent container, retrying..."
-                sleep 10
-              done
-              echo "[CMD] start.sh process found."
-              while pgrep start.sh > /dev/null; do
-                sleep 1
-              done
-              exit 0
-          volumeMounts:
-            - name: buildkitd-certs
-              mountPath: /certs
-              readOnly: true
-            - name: buildkitd-workspace
-              mountPath: /home/user/.local/share/buildkit
-        {{- end }}
-        {{- if .Values.sidecarContainers.docker.enabled }}
-        - name: dind
-          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
-          securityContext:
-            privileged: true
-          env: 
-            - name: DOCKER_TLS_CERTDIR
-              value: /dind-certs
-          volumeMounts:
-            - mountPath: /dind-certs
-              name: dind-certs
-        {{- end }}
         tolerations:
         - key: "pool"
           operator: "Equal"

--- a/charts/ado-build-agents/templates/scalejob.yaml
+++ b/charts/ado-build-agents/templates/scalejob.yaml
@@ -63,6 +63,51 @@ spec:
             - name: buildkitd-certs
               mountPath: /certs
         {{- end }}
+        {{- if .Values.sidecarContainers.buildkit.enabled }}
+        - name: buildkitd
+          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              add:
+                - SYS_PTRACE
+                - KILL
+            seccompProfile:
+              type: Unconfined
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "[CMD] Starting buildkitd...";
+              rootlesskit buildkitd \
+                --oci-worker-no-process-sandbox \
+                --addr tcp://0.0.0.0:1234 \
+                --addr unix:///run/user/1000/buildkit/buildkitd.sock \
+                --tlscacert /certs/server/ca.pem \
+                --tlscert /certs/server/cert.pem \
+                --tlskey /certs/server/key.pem
+          volumeMounts:
+            - name: buildkitd-certs
+              mountPath: /certs
+              readOnly: true
+            - name: buildkitd-workspace
+              mountPath: /home/user/.local/share/buildkit
+        {{- end }}
+        {{- if .Values.sidecarContainers.docker.enabled }}
+        - name: dind
+          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
+          restartPolicy: Always
+          securityContext:
+            privileged: true
+          env: 
+            - name: DOCKER_TLS_CERTDIR
+              value: /dind-certs
+          volumeMounts:
+            - mountPath: /dind-certs
+              name: dind-certs
+        {{- end }}
         containers:
           # PROTIP - In Keda agent container has to be first, otherwise it will not be able to read value from AZP_URL
         - name: {{ .Values.buildAgentName }}
@@ -122,76 +167,6 @@ spec:
               mountPath: /dind-certs
               readOnly: true
             {{- end }}
-        {{- if .Values.sidecarContainers.buildkit.enabled }}
-        - name: buildkitd
-          image: {{ .Values.devops.ACR_NAME }}/dockerhub/moby/{{ .Values.sidecarContainers.buildkit.image }}
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            capabilities:
-              add:
-                - SYS_PTRACE
-                - KILL
-            seccompProfile:
-              type: Unconfined
-          readinessProbe:
-            exec:
-              command:
-              - buildctl
-              - debug
-              - workers
-            failureThreshold: 3
-            initialDelaySeconds: 3
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 1
-          command: ["/bin/sh", "-c"]
-          args:
-            - |
-              echo "[CMD] Starting buildkitd...";
-              rootlesskit buildkitd \
-                --oci-worker-no-process-sandbox \
-                --addr tcp://0.0.0.0:1234 \
-                --addr unix:///run/user/1000/buildkit/buildkitd.sock \
-                --tlscacert /certs/server/ca.pem \
-                --tlscert /certs/server/cert.pem \
-                --tlskey /certs/server/key.pem &
-              attempts=0
-              max_attempts=30
-              while ! pgrep start.sh > /dev/null; do
-                attempts=$((attempts + 1))
-                if [ $attempts -ge $max_attempts ]; then
-                  echo "[CMD] Failed to find start.sh after $max_attempts attempts. Exiting with status 1."
-                  exit 1
-                fi
-                echo "[CMD] Failed to find process start.sh from agent container, retrying..."
-                sleep 10
-              done
-              echo "[CMD] start.sh process found."
-              while pgrep start.sh > /dev/null; do
-                sleep 1
-              done
-              exit 0
-          volumeMounts:
-            - name: buildkitd-certs
-              mountPath: /certs
-              readOnly: true
-            - name: buildkitd-workspace
-              mountPath: /home/user/.local/share/buildkit
-        {{- end }}
-        {{- if .Values.sidecarContainers.docker.enabled }}
-        - name: dind
-          image: {{ .Values.sidecarContainers.docker.image | default "docker:dind" }}
-          securityContext:
-            privileged: true
-          env: 
-            - name: DOCKER_TLS_CERTDIR
-              value: /dind-certs
-          volumeMounts:
-            - mountPath: /dind-certs
-              name: dind-certs
-        {{- end }}
         tolerations:
         - key: "pool"
           operator: "Equal"


### PR DESCRIPTION
## Description

Moved AKS Agents sidecar definitions to init containers to remove termination logic from custom script.
Right now sidecars should be automatically killed once main container is terminated.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`