### PR TITLE
remove acr-pull-secret from values

### DIFF
--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.7.0
+version: 2.7.1
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/cron-job/Chart.yaml
+++ b/charts/cron-job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Cron Job
 name: charts-cron-job
 type: application
-version: 2.7.1
+version: 2.8.0
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -6,7 +6,6 @@ global:
   schedule: ""
   image:
     repository: "cicdcr01weuy01.azurecr.io"
-    imagePullSecret: "acr-pull-secret"
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -6,6 +6,7 @@ global:
   schedule: ""
   image:
     repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: ""
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.2.0
+version: 4.2.1
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.2.1
+version: 4.3.0
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -43,6 +43,7 @@ global:
   mockingServer:
     enabled: false
     repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: ""
     name: "dockerhub/mockserver/mockserver"
     tag: "5.13.2"
     pullPolicy: IfNotPresent

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -7,7 +7,6 @@ global:
 
   image:
     repository: "cicdcr01weuy01.azurecr.io"
-    imagePullSecret: "acr-pull-secret"
     name: ""
     tag: ""
     pullPolicy: IfNotPresent
@@ -44,7 +43,6 @@ global:
   mockingServer:
     enabled: false
     repository: "cicdcr01weuy01.azurecr.io"
-    imagePullSecret: "acr-pull-secret"
     name: "dockerhub/mockserver/mockserver"
     tag: "5.13.2"
     pullPolicy: IfNotPresent

--- a/charts/event-worker/Chart.yaml
+++ b/charts/event-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Deployment
 name: charts-event-worker
 type: application
-version: 1.0.1
+version: 1.1.0
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/event-worker/Chart.yaml
+++ b/charts/event-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Deployment
 name: charts-event-worker
 type: application
-version: 1.0.0
+version: 1.0.1
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/event-worker/values.yaml
+++ b/charts/event-worker/values.yaml
@@ -12,6 +12,7 @@ global:
 
   image:
     repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: ""
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/event-worker/values.yaml
+++ b/charts/event-worker/values.yaml
@@ -12,7 +12,6 @@ global:
 
   image:
     repository: "cicdcr01weuy01.azurecr.io"
-    imagePullSecret: "acr-pull-secret"
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.7.0
+version: 2.7.1
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/job/Chart.yaml
+++ b/charts/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for K8s Event driven Job
 name: charts-job
 type: application
-version: 2.7.1
+version: 2.8.0
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -5,6 +5,7 @@
 global:
   image:
     repository: "cicdcr01weuy01.azurecr.io"
+    imagePullSecret: ""
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/job/values.yaml
+++ b/charts/job/values.yaml
@@ -5,7 +5,6 @@
 global:
   image:
     repository: "cicdcr01weuy01.azurecr.io"
-    imagePullSecret: "acr-pull-secret"
     name: # app name
     tag: "" #"10.64.1"
     pullPolicy: IfNotPresent

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: EcoVadis public Helm chart for Pact Broker
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: 2.102.2.0
 sources:
   - https://github.com/pact-foundation/pact_broker

--- a/charts/pact-broker/Chart.yaml
+++ b/charts/pact-broker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pact-broker
 description: EcoVadis public Helm chart for Pact Broker
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 2.102.2.0
 sources:
   - https://github.com/pact-foundation/pact_broker

--- a/charts/pact-broker/values.yaml
+++ b/charts/pact-broker/values.yaml
@@ -4,8 +4,6 @@ image:
   repository: dockerhub/pactfoundation/pact-broker # -- Pact Broker image repository
   tag: 2.102.2.0 # -- Pact Broker image tag (immutable tags are recommended) https://hub.docker.com/r/pactfoundation/pact-broker/tags
   pullPolicy: IfNotPresent # -- Specify a imagePullPolicy
-  pullSecrets: # -- Array of imagePullSecrets to allow pulling the Pact Broker image from private registries: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    - acr-pull-secret # -- It is recommended to create this secret and store docker.io credentials inside. Even when we are pulling image from a public repo there are may be transient errors when pulling without imagePullSecrets.
 
 envVars:
   PACT_BROKER_DATABASE_ADAPTER: "postgres" # -- Database engine to use.


### PR DESCRIPTION
## Description

We are not using these secrets anymore and they create unnecessary warnings in deployments:
```
FailedToRetrieveImagePullSecret
Unable to retrieve some image pull secrets (acr-pull-secret); attemtping to pull the image may not succeed.
```

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [x] cron-job
- [x] job
- [x ] app-reverse-proxy
- [x] pact-broker
- [ ] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`