### PR TITLE
skip analysis for canary deployments

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.3.0
+version: 4.4.0
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/dotnet-core/templates/CRD/canary.yaml
+++ b/charts/dotnet-core/templates/CRD/canary.yaml
@@ -30,6 +30,7 @@ spec:
     apex:
       labels:
         {{- include "charts-dotnet-core.labels" . | nindent 8 }}
+  skipAnalysis: {{ .Values.global.canary.skipAnalysis }}
   analysis:
     {{- toYaml .Values.global.canary.analysis.settings | nindent 4}}
     metrics:

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -223,10 +223,12 @@ global:
     targetCPUUtilizationPercentage: 70
 
   canary:
-    enabled: false # Setting to enable or disable canary deployments with Flagger.
+    enabled: true # Setting to enable or disable canary deployments with Flagger.
     progressDeadlineSeconds: 600 # the maximum time in seconds for the canary deployment to make progress before it is rollback
     portDiscovery:
       enabled: true # auto discover pod ports from deployment spec and add them to k8s service that created by Flagger
+
+    skipAnalysis: true # skip analysis phase and promote canary to primary if set to true
 
     analysis:
       settings:
@@ -246,7 +248,7 @@ global:
       endpoint: /readyz # service endpoint to do an acceptance test. Readiness health probe is default, so acceptance test Url looks like http://service.namespace/readyz/ by default.
 
     loadTesting:
-      enabled: true # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.
+      enabled: false # [bool] enable or disable load testing with Flagger load tester based on 'hey' tool.
       endpoint: /readyz # service endpoint to do a load test. Readiness health probe is default, so load test Url looks like http://service.namespace/readyz/ by default.
       serviceName: flagger-loadtester # name of Flagger load tester k8s service
       namespace: flagger-system # namespace of Flagger load tester k8s service


### PR DESCRIPTION
## Description

Briefly describe the problem and solution. Please remember to create 1 PR per 1 chart in case of dependency between them, otherwise PR gate will fail.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`