### PR TITLE
Fix autoscaling with canary bug - always create HPA

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.4.0
+version: 4.4.1
 dependencies:
 - name: charts-core
   version: 2.4.2

--- a/charts/dotnet-core/templates/hpa.yaml
+++ b/charts/dotnet-core/templates/hpa.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -11,7 +10,11 @@ spec:
     kind: Deployment
     name: {{ include "charts-dotnet-core.fullname" . }}
   minReplicas: {{ .Values.global.replicaCount }}
+{{- if .Values.global.autoscaling.enabled }}
   maxReplicas: {{ .Values.global.autoscaling.maxReplicas }}
+{{ else }}
+  maxReplicas: {{ .Values.global.replicaCount }}
+{{- end }}
   metrics:
   {{- if .Values.global.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -29,4 +32,3 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.global.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
-{{- end }}


### PR DESCRIPTION
## Description

Briefly describe the problem and solution. Please remember to create 1 PR per 1 chart in case of dependency between them, otherwise PR gate will fail.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`