### PR TITLE
Separated identity used by Keda ADO autoscaler

### DIFF
--- a/charts/ado-build-agents/Chart.yaml
+++ b/charts/ado-build-agents/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart with Keda scalable Azure Devops build agent for Kubernetes
 name: charts-ado-build-agents
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.0"

--- a/charts/ado-build-agents/templates/service-account.yaml
+++ b/charts/ado-build-agents/templates/service-account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    azure.workload.identity/client-id: {{ $.Values.aadIdentity }}
+    azure.workload.identity/client-id: {{ $.Values.agentAadIdentity }}
     meta.helm.sh/release-name: "{{ .Release.Name }}"
     meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
   labels:

--- a/charts/ado-build-agents/templates/triggerauth.yaml
+++ b/charts/ado-build-agents/templates/triggerauth.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   podIdentity:
     provider: azure-workload
-    identityId: {{ $.Values.aadIdentity }}
+    identityId: {{ $.Values.keda.aadIdentity }}
     identityTenantId: {{ .Values.tenantId }}
 ---

--- a/charts/ado-build-agents/values.yaml
+++ b/charts/ado-build-agents/values.yaml
@@ -12,8 +12,8 @@ aks:
   sysbox:
     enabled: false
 
-# Application ID of the kubelet user assigned identity form Azure
-aadIdentity: xxxxxx-xxxx-xxxx-xxxx
+# Application ID of identity used by build agent
+agentAadIdentity: xxxxxx-xxxx-xxxx-xxxx
 # Tenant ID of the kubelet user assigned identity from Azure
 tenantId : xxxxxx-xxxx-xxxx-xxxx
 
@@ -56,6 +56,8 @@ sidecarContainers:
     image: buildkit:v0.21.1-rootless
 
 keda:
+  # Azure Identity to be used by Keda scaler
+  aadIdentity: xxxxxx-xxxx-xxxx-xxxx
   # Minimum number of replicas to be deployed, should be >= 1
   minReplicas: "1"
   # Maximum number of replicas to be deployed


### PR DESCRIPTION
## Description

Allows specyfing separate identites used for Keda and build agent

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [x] ado-build-agents

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`