### PR TITLE
Added shared folder for agent and docker containers

### DIFF
--- a/charts/ado-build-agents/Chart.yaml
+++ b/charts/ado-build-agents/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart with Keda scalable Azure Devops build agent for Kubernetes
 name: charts-ado-build-agents
-version: 3.7.0
+version: 3.8.0
 appVersion: "1.0"

--- a/charts/ado-build-agents/templates/scalejob.yaml
+++ b/charts/ado-build-agents/templates/scalejob.yaml
@@ -31,6 +31,8 @@ spec:
           {{- if .Values.linuxSidecarContainers.docker.enabled }}
           - name: dind-certs
             emptyDir: {}
+          - name: dind-share
+            emptyDir: {}
           {{- end }}
           {{- if .Values.linuxSidecarContainers.buildkit.enabled }}
           - name: buildkitd-certs
@@ -113,6 +115,9 @@ spec:
             volumeMounts:
               - mountPath: /dind-certs
                 name: dind-certs
+              - mountPath: /dind-share
+                name: dind-share
+                readOnly: false
           {{- end }}
           {{- if .Values.windowsSidecarContainers.sqlserver.enabled }}
           - name: sqlserver
@@ -244,6 +249,9 @@ spec:
             - name: dind-certs
               mountPath: /dind-certs
               readOnly: true
+            - name: dind-share
+              mountPath: /dind-share
+              readOnly: false
               {{- end }}
             {{- end }}
             {{- if .Values.agent.os | eq "windows" }}


### PR DESCRIPTION
## Description

There was a problem when pipeline starts container and it requires to mount files.
Agent container triggers command to mount files from ~/bind, but sidecar container with docker obviously doesn't have this folder. This PR creates sharable folder "/dind-share", so agent can place required files there and it will be usable by docker.

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [x] ado-build-agents
- [ ] ado-agent-cleaner
- [ ] event-worker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`