### PR TITLE
Added possibility to specify custom secret name to be passed

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.9.0
+version: 4.10.0
 dependencies:
 - name: charts-core
   version: "2.8.0"

--- a/charts/dotnet-core/templates/deployment.yaml
+++ b/charts/dotnet-core/templates/deployment.yaml
@@ -173,7 +173,7 @@ spec:
           {{- end }}
           {{- end }}
 
-          {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled }}
+          {{- if or .Values.global.envVarsEnabled .Values.global.secEnvVarsEnabled .Values.global.extraEnvFrom }}
           envFrom:
           {{- if .Values.global.envVarsEnabled }}
             - configMapRef:
@@ -182,6 +182,9 @@ spec:
           {{- if .Values.global.secEnvVarsEnabled }}
             - secretRef:
                 name: "{{ include "charts-dotnet-core.fullname" . }}-secure"
+          {{- end }}
+          {{- if .Values.global.extraEnvFrom }}
+            {{- toYaml .Values.global.extraEnvFrom | nindent 12 }}
           {{- end }}
           {{- end }}
           env:

--- a/charts/dotnet-core/templates/tests/deployment_test.py
+++ b/charts/dotnet-core/templates/tests/deployment_test.py
@@ -648,6 +648,88 @@ class DeploymentTemplateFileTest(unittest.TestCase):
             ],
             jmespath.search("spec.template.spec.topologySpreadConstraints", docs[0]))
 
+    def test_should_add_extra_env_from_with_secret_ref(self):
+        docs = render_chart(
+            values={
+                "global": {
+                    "envVarsEnabled": False,
+                    "secEnvVarsEnabled": False,
+                    "extraEnvFrom": [
+                        {
+                            "secretRef": {
+                                "name": "my-existing-secret"
+                            }
+                        }
+                    ]
+                }
+            },
+            name=".",
+            show_only=["templates/deployment.yaml"]
+        )
+        self.assertEqual(
+            "my-existing-secret",
+            jmespath.search(
+                "spec.template.spec.containers[0].envFrom[0].secretRef.name", docs[0])
+        )
+
+    def test_should_add_extra_env_from_with_config_map_ref(self):
+        docs = render_chart(
+            values={
+                "global": {
+                    "envVarsEnabled": False,
+                    "secEnvVarsEnabled": False,
+                    "extraEnvFrom": [
+                        {
+                            "configMapRef": {
+                                "name": "my-existing-configmap"
+                            }
+                        }
+                    ]
+                }
+            },
+            name=".",
+            show_only=["templates/deployment.yaml"]
+        )
+        self.assertEqual(
+            "my-existing-configmap",
+            jmespath.search(
+                "spec.template.spec.containers[0].envFrom[0].configMapRef.name", docs[0])
+        )
+
+    def test_should_add_extra_env_from_alongside_existing_refs(self):
+        docs = render_chart(
+            values={
+                "global": {
+                    "envVarsEnabled": True,
+                    "secEnvVarsEnabled": True,
+                    "extraEnvFrom": [
+                        {
+                            "secretRef": {
+                                "name": "my-existing-secret"
+                            }
+                        }
+                    ]
+                }
+            },
+            name=".",
+            show_only=["templates/deployment.yaml"]
+        )
+        self.assertEqual(
+            "release-name-charts-dotnet-core",
+            jmespath.search(
+                "spec.template.spec.containers[0].envFrom[0].configMapRef.name", docs[0])
+        )
+        self.assertEqual(
+            "release-name-charts-dotnet-core-secure",
+            jmespath.search(
+                "spec.template.spec.containers[0].envFrom[1].secretRef.name", docs[0])
+        )
+        self.assertEqual(
+            "my-existing-secret",
+            jmespath.search(
+                "spec.template.spec.containers[0].envFrom[2].secretRef.name", docs[0])
+        )
+
     def test_fileshare_mount(self):
 
         share_name = "files"

--- a/charts/dotnet-core/templates/tests/deployment_test.py
+++ b/charts/dotnet-core/templates/tests/deployment_test.py
@@ -715,12 +715,12 @@ class DeploymentTemplateFileTest(unittest.TestCase):
             show_only=["templates/deployment.yaml"]
         )
         self.assertEqual(
-            "release-name-charts-dotnet-core",
+            "RELEASE-NAME-charts-dotnet-core",
             jmespath.search(
                 "spec.template.spec.containers[0].envFrom[0].configMapRef.name", docs[0])
         )
         self.assertEqual(
-            "release-name-charts-dotnet-core-secure",
+            "RELEASE-NAME-charts-dotnet-core-secure",
             jmespath.search(
                 "spec.template.spec.containers[0].envFrom[1].secretRef.name", docs[0])
         )

--- a/charts/dotnet-core/values.yaml
+++ b/charts/dotnet-core/values.yaml
@@ -169,6 +169,12 @@ global:
   secEnvVarsEnabled: true
   secEnvVars: {}
 
+  extraEnvFrom: []
+  #   - secretRef:
+  #       name: my-existing-secret
+  #   - configMapRef:
+  #       name: my-existing-configmap
+
   appConfigFilesEnabled: true
   appConfigFiles:
     globPattern: "**.json"


### PR DESCRIPTION
## Description

Right now there is no way to specify secret generated outside of the chart to be passed as environment variables making custom non-microservices dotnet deployments hard to pass secrets.
It adds such possibility without breaking current flow - fully backward compatible.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents
- [ ] ado-agent-cleaner
- [ ] event-worker

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`