### PR TITLE
Added possibility to add env variables to ado agent cleaner chart

### DIFF
--- a/charts/ado-agent-cleaner/Chart.yaml
+++ b/charts/ado-agent-cleaner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: Helper to clean up stale AKS Azure DevOps agents
 name: charts-ado-agent-cleaner
-version: 1.0.1
+version: 1.1.0
 appVersion: "1.0"

--- a/charts/ado-agent-cleaner/templates/cronjob.yaml
+++ b/charts/ado-agent-cleaner/templates/cronjob.yaml
@@ -28,5 +28,8 @@ spec:
             env:
               - name: AZP_URL
                 value: "{{ .Values.devopsOrgUrl }}"
+              {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
             resources:
               {{  toYaml .Values.resources | nindent 14 }}

--- a/charts/ado-agent-cleaner/values.yaml
+++ b/charts/ado-agent-cleaner/values.yaml
@@ -7,6 +7,18 @@ podName: agent-cleaner
 # Container Image Name for the Agent Cleaner
 imageName: aksagentcleaner:1.0.0
 
+# Additional environment variables to add to the Agent Cleaner container.
+# By default nothing is added. Provide a list of standard Kubernetes env entries, e.g.:
+# extraEnv:
+#   - name: MY_VAR
+#     value: "my-value"
+#   - name: MY_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+extraEnv: []
+
 # Settings specific for the CronJob
 cronSettings:
   schedule: "*/30 * * * *"
@@ -24,3 +36,5 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+
+    


### PR DESCRIPTION
## Description

Added possibility to add env variables to ado agent cleaner chart

## Chart

Select the chart that you are modifying:
- [ ] core
- [ ] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents
- [x] ado-agent-cleaner
- [ ] event-worker

## Checklist
- [ ] Description provided
- [ ] Linked issue
- [ ] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`