### PR TITLE
Allow scaling to zero if canary not enabled

### DIFF
--- a/charts/dotnet-core/Chart.yaml
+++ b/charts/dotnet-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: EcoVadis Helm chart for .Net Core app
 name: charts-dotnet-core
 type: application
-version: 4.10.0
+version: 4.11.0
 dependencies:
 - name: charts-core
   version: "2.8.0"

--- a/charts/dotnet-core/templates/hpa.yaml
+++ b/charts/dotnet-core/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.global.canary.enabled (gt (.Values.global.replicaCount | int) 0) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -32,3 +33,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.global.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

Allow scale-to-zero (replicaCount: 0) on the dotnet-core chart without breaking helm upgrade.

  Today the HPA template is unconditional (since #158), so setting replicaCount: 0 always fails with:

  spec.minReplicas: Invalid value: 0: must be greater than or equal to 1
  spec.maxReplicas: Invalid value: 0: must be greater than 0

  This is a hard K8s constraint — Resource-metric (CPU/memory) HPAs can never scale to zero, regardless of chart config. #158 made HPA creation unconditional specifically because Flagger's
  Canary CRD (autoscalerRef) requires the HPA to exist whenever canary.enabled: true; skipping it broke canary rollouts.

  Fix: skip HPA creation only when replicaCount: 0 and canary is disabled — {{- if or .Values.global.canary.enabled (gt (.Values.global.replicaCount | int) 0) }}. Deployment already
  renders replicas directly from replicaCount, so with HPA skipped, replicaCount: 0 now suspends the workload cleanly.

  Canary + replicaCount: 0 still isn't supported (HPA still forced to exist to satisfy Flagger, still fails K8s validation) — that combination is fundamentally incompatible, not something
  the chart can fix.

## Chart

Select the chart that you are modifying:
- [ ] core
- [x] dotnet-core
- [ ] cron-job
- [ ] job
- [ ] app-reverse-proxy
- [ ] pact-broker
- [ ] ado-build-agents
- [ ] ado-agent-cleaner
- [ ] event-worker

## Checklist
- [x] Description provided
- [ ] Linked issue
- [x] Chart version bumped
- [ ] README.md updated with any new values or changes
- [ ] Updated template tests in `${CHART}/tests/*.py`